### PR TITLE
ref: change the signature of the client handler to use servant (#230)

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -21,19 +21,19 @@ type buildArtefacts struct {
 // for Walk and one for Run. The Prime/Resume extents create the Builders
 // instance.
 type Builders struct {
-	using      *pref.Using
-	traverseFS pref.TraverseFileSystemBuilder
-	options    optionsBuilder
-	navigator  kernel.NavigatorBuilder
-	plugins    pluginsBuilder
-	extent     extentBuilder
+	using     *pref.Using
+	fS        pref.TraverseFileSystemBuilder
+	options   optionsBuilder
+	navigator kernel.NavigatorBuilder
+	plugins   pluginsBuilder
+	extent    extentBuilder
 }
 
 func (bs *Builders) buildAll() (*buildArtefacts, error) {
 	// BUILD FILE SYSTEM & EXTENT
 	//
 	ext := bs.extent.build(
-		bs.traverseFS.Build(bs.using.Tree),
+		bs.fS.Build(bs.using.Tree),
 	)
 
 	// BUILD OPTIONS

--- a/concurrent-defs.go
+++ b/concurrent-defs.go
@@ -8,9 +8,9 @@ import (
 type (
 	// TraverseInput represents the type  of inputs accepted by the worker pool
 	TraverseInput struct {
-		// Node represents the file system entity (file or folder) for which
+		// Servant represents the file system entity (file or folder) for which
 		// a job will execute.
-		Node *core.Node
+		Servant Servant
 
 		// Handler is the client defined callback function that should be
 		// invoked for all eligible Nodes.
@@ -31,9 +31,9 @@ type (
 
 	// TraverseOutput represents the output of a single job executed by the pool.
 	TraverseOutput struct {
-		// Node represents the file system entity (file or folder) from
+		// Servant represents the file system entity (file or folder) from
 		// which this output was generated via the client defined handler.
-		Node *core.Node
+		Servant Servant
 
 		// Error error result of client's handler.
 		Error error

--- a/core/core-defs.go
+++ b/core/core-defs.go
@@ -31,9 +31,15 @@ type (
 		Error() error
 	}
 
+	// Servant provides the client with facility to request properties
+	// about the current navigation node.
+	Servant interface {
+		Node() *Node
+	}
+
 	// Client is the callback invoked for each file system node found
 	// during traversal.
-	Client func(node *Node) error
+	Client func(servant Servant) error
 
 	// SimpleHandler is a function that takes no parameters and can
 	// be used by any notification with this signature.
@@ -48,10 +54,6 @@ type (
 	// HibernateHandler is a generic handler that is used by hibernation
 	// to indicate wake or sleep.
 	HibernateHandler func(description string)
-
-	// NodeHandler is a generic handler that is for any notification that contains
-	// the traversal node, such as directory ascend or descend.
-	NodeHandler func(node *Node)
 )
 
 func (fn Completion) IsComplete() bool {

--- a/director-error_test.go
+++ b/director-error_test.go
@@ -27,7 +27,7 @@ var _ = Describe("director error", Ordered, func() {
 	var handler tv.Client
 
 	BeforeAll(func() {
-		handler = func(_ *tv.Node) error {
+		handler = func(_ tv.Servant) error {
 			return nil
 		}
 		Expect(li18ngo.Use(
@@ -120,7 +120,7 @@ var _ = Describe("director error", Ordered, func() {
 			_, err := tv.Walk().Configure().Extent(tv.Prime(
 				&tv.Using{
 					Tree: TreePath,
-					Handler: func(_ *tv.Node) error {
+					Handler: func(_ tv.Servant) error {
 						return nil
 					},
 				},
@@ -141,7 +141,7 @@ var _ = Describe("director error", Ordered, func() {
 				&tv.Using{
 					Tree:         TreePath,
 					Subscription: tv.SubscribeFiles,
-					Handler: func(_ *tv.Node) error {
+					Handler: func(_ tv.Servant) error {
 						return nil
 					},
 				},
@@ -166,7 +166,7 @@ var _ = Describe("director error", Ordered, func() {
 			_, err := tv.Run(&wg).Configure().Extent(tv.Prime(
 				&tv.Using{
 					Tree: TreePath,
-					Handler: func(_ *tv.Node) error {
+					Handler: func(_ tv.Servant) error {
 						return nil
 					},
 				},
@@ -186,7 +186,7 @@ var _ = Describe("director error", Ordered, func() {
 			_, _ = tv.Walk().Configure().Extent(tv.Prime(
 				&tv.Using{
 					Tree: TreePath,
-					Handler: func(_ *tv.Node) error {
+					Handler: func(_ tv.Servant) error {
 						return nil
 					},
 				},

--- a/director.go
+++ b/director.go
@@ -78,7 +78,7 @@ func features(o *pref.Options, using *pref.Using, mediator types.Mediator,
 func Prime(using *pref.Using, settings ...pref.Option) *Builders {
 	return &Builders{
 		using: using,
-		traverseFS: pref.CreateTraverseFS(func(root string) TraverseFS {
+		fS: pref.CreateTraverseFS(func(root string) TraverseFS {
 			if using.GetTraverseFS != nil {
 				return using.GetTraverseFS(root)
 			}
@@ -88,11 +88,11 @@ func Prime(using *pref.Using, settings ...pref.Option) *Builders {
 				Overwrite: noOverwrite,
 			})
 		}),
-		extent: extension(func(tsys TraverseFS) extent {
+		extent: extension(func(fS TraverseFS) extent {
 			return &primeExtent{
 				baseExtent: baseExtent{
 					fileSys: fileSystems{
-						tsys: tsys,
+						fS: fS,
 					},
 				},
 				u: using,
@@ -129,7 +129,7 @@ func Prime(using *pref.Using, settings ...pref.Option) *Builders {
 func Resume(was *Was, settings ...pref.Option) *Builders {
 	return &Builders{
 		using: &was.Using,
-		traverseFS: pref.CreateTraverseFS(func(root string) TraverseFS {
+		fS: pref.CreateTraverseFS(func(root string) TraverseFS {
 			if was.Using.GetTraverseFS != nil {
 				return was.Using.GetTraverseFS(root)
 			}
@@ -139,11 +139,11 @@ func Resume(was *Was, settings ...pref.Option) *Builders {
 				Overwrite: noOverwrite,
 			})
 		}),
-		extent: extension(func(tsys TraverseFS) extent {
+		extent: extension(func(fS TraverseFS) extent {
 			return &resumeExtent{
 				baseExtent: baseExtent{
 					fileSys: fileSystems{
-						tsys: tsys,
+						fS: fS,
 					},
 				},
 				w: was,

--- a/extent.go
+++ b/extent.go
@@ -18,7 +18,7 @@ type extent interface {
 }
 
 type fileSystems struct {
-	tsys TraverseFS
+	fS TraverseFS
 }
 
 type baseExtent struct {
@@ -26,7 +26,7 @@ type baseExtent struct {
 }
 
 func (ex *baseExtent) traverseFS() TraverseFS {
-	return ex.fileSys.tsys
+	return ex.fileSys.fS
 }
 
 type primeExtent struct {
@@ -81,7 +81,7 @@ func (ex *resumeExtent) plugin(artefacts *kernel.Artefacts) types.Plugin {
 }
 
 func (ex *resumeExtent) options(settings ...pref.Option) (*pref.Options, *opts.Binder, error) {
-	loaded, binder, err := resume.Load(ex.fileSys.tsys, ex.w.From, settings...)
+	loaded, binder, err := resume.Load(ex.fileSys.fS, ex.w.From, settings...)
 	ex.loaded = loaded
 
 	// TODO: get the resume point from the resume persistence file

--- a/internal-traverse-defs.go
+++ b/internal-traverse-defs.go
@@ -56,13 +56,13 @@ func (fn filesystem) build(path string) fs.FS {
 }
 
 type extentBuilder interface {
-	build(tsys TraverseFS) extent
+	build(fS TraverseFS) extent
 }
 
-type extension func(tsys TraverseFS) extent
+type extension func(fS TraverseFS) extent
 
-func (fn extension) build(tsys TraverseFS) extent {
-	return fn(tsys)
+func (fn extension) build(fS TraverseFS) extent {
+	return fn(fS)
 }
 
 // We need an entity that manages the decoration of the client handler. The

--- a/internal/feat/filter/filter-plugin.go
+++ b/internal/feat/filter/filter-plugin.go
@@ -43,8 +43,10 @@ func (p *plugin) Register(kc types.KernelController) error {
 	return p.scheme.create()
 }
 
-func (p *plugin) Next(node *core.Node, inspection types.Inspection) (bool, error) {
-	return p.scheme.next(node, inspection)
+func (p *plugin) Next(servant core.Servant,
+	inspection types.Inspection,
+) (bool, error) {
+	return p.scheme.next(servant, inspection)
 }
 
 func (p *plugin) Init(pi *types.PluginInit) error {

--- a/internal/feat/filter/scheme-custom.go
+++ b/internal/feat/filter/scheme-custom.go
@@ -19,10 +19,10 @@ func (s *customScheme) create() error {
 	return s.filter.Validate()
 }
 
-func (s *customScheme) next(node *core.Node,
+func (s *customScheme) next(servant core.Servant,
 	_ types.Inspection,
 ) (bool, error) {
-	return matchNext(s.filter, node, s.crate)
+	return matchNext(s.filter, servant.Node(), s.crate)
 }
 
 func matchNext(filter core.TraverseFilter,

--- a/internal/feat/filter/scheme-hybrid.go
+++ b/internal/feat/filter/scheme-hybrid.go
@@ -52,16 +52,16 @@ func (s *hybridScheme) init(pi *types.PluginInit, crate *measure.Crate) {
 	}
 }
 
-func (s *hybridScheme) next(node *core.Node,
+func (s *hybridScheme) next(servant core.Servant,
 	inspection types.Inspection,
 ) (bool, error) {
 	if s.primary != nil {
-		invokeNext, err := s.primary.next(node, inspection)
+		invokeNext, err := s.primary.next(servant, inspection)
 
 		if invokeNext && s.nanny != nil {
 			// The nanny has no say in wether the next link is invoked,
 			// therefore we ignore its next result
-			_, err := s.nanny.next(node, inspection)
+			_, err := s.nanny.next(servant, inspection)
 
 			return invokeNext, err
 		}

--- a/internal/feat/filter/scheme-nanny.go
+++ b/internal/feat/filter/scheme-nanny.go
@@ -35,7 +35,9 @@ func (s *nannyScheme) init(pi *types.PluginInit, crate *measure.Crate) {
 	s.common.init(pi, crate)
 }
 
-func (s *nannyScheme) next(_ *core.Node, inspection types.Inspection) (bool, error) {
+func (s *nannyScheme) next(_ core.Servant,
+	inspection types.Inspection,
+) (bool, error) {
 	files := inspection.Sort(enums.EntryTypeFile)
 	matching := s.filter.Matching(files)
 

--- a/internal/feat/filter/scheme-native.go
+++ b/internal/feat/filter/scheme-native.go
@@ -29,8 +29,8 @@ func (s *nativeScheme) create() error {
 	return nil
 }
 
-func (s *nativeScheme) next(node *core.Node,
+func (s *nativeScheme) next(servant core.Servant,
 	_ types.Inspection,
 ) (bool, error) {
-	return matchNext(s.filter, node, s.crate)
+	return matchNext(s.filter, servant.Node(), s.crate)
 }

--- a/internal/feat/filter/scheme-sampler.go
+++ b/internal/feat/filter/scheme-sampler.go
@@ -38,9 +38,11 @@ func (s *samplerScheme) create() error {
 	return filter.Validate()
 }
 
-func (s *samplerScheme) next(node *core.Node,
+func (s *samplerScheme) next(servant core.Servant,
 	inspection types.Inspection,
 ) (bool, error) {
+	node := servant.Node()
+
 	if node.Extension.Scope.IsTree() {
 		matching := s.filter.Matching(
 			[]fs.DirEntry{nef.FromFileInfo(node.Info)},

--- a/internal/feat/filter/schemes.go
+++ b/internal/feat/filter/schemes.go
@@ -12,7 +12,7 @@ type (
 	scheme interface {
 		create() error
 		init(pi *types.PluginInit, crate *measure.Crate)
-		next(node *core.Node, inspection types.Inspection) (bool, error)
+		next(servant core.Servant, inspection types.Inspection) (bool, error)
 	}
 )
 

--- a/internal/feat/hiber/hibernate-defs.go
+++ b/internal/feat/hiber/hibernate-defs.go
@@ -29,7 +29,9 @@ func RestoreOptions() {
 }
 
 type (
-	nextFn func(node *core.Node, inspection types.Inspection) (bool, error)
+	nextFn func(servant core.Servant, node *core.Node,
+		inspection types.Inspection,
+	) (bool, error)
 
 	state struct {
 		next nextFn
@@ -43,7 +45,9 @@ type (
 
 	profile interface {
 		init(controls *cycle.Controls) error
-		next(node *core.Node, inspection types.Inspection) (bool, error)
+		next(servant core.Servant, node *core.Node,
+			inspection types.Inspection,
+		) (bool, error)
 	}
 
 	common struct {

--- a/internal/feat/hiber/hibernate-plugin.go
+++ b/internal/feat/hiber/hibernate-plugin.go
@@ -32,8 +32,10 @@ type plugin struct {
 	profile profile
 }
 
-func (p *plugin) Next(node *core.Node, inspection types.Inspection) (bool, error) {
-	return p.profile.next(node, inspection)
+func (p *plugin) Next(servant core.Servant,
+	inspection types.Inspection,
+) (bool, error) {
+	return p.profile.next(servant, servant.Node(), inspection)
 }
 
 func (p *plugin) Init(pi *types.PluginInit) error {

--- a/internal/feat/hiber/hibernate-simple-profile.go
+++ b/internal/feat/hiber/hibernate-simple-profile.go
@@ -65,14 +65,14 @@ func (p *simple) transition(en enums.Hibernation) {
 	p.current = p.states[en]
 }
 
-func (p *simple) next(node *core.Node, inspection types.Inspection) (bool, error) {
-	return p.current.next(node, inspection)
+func (p *simple) next(servant core.Servant, node *core.Node, inspection types.Inspection) (bool, error) {
+	return p.current.next(servant, node, inspection)
 }
 
 func (p *simple) create() hibernateStates {
 	return hibernateStates{
 		enums.HibernationPending: state{
-			next: func(node *core.Node, _ types.Inspection) (bool, error) {
+			next: func(_ core.Servant, node *core.Node, _ types.Inspection) (bool, error) {
 				if p.common.triggers.wake.IsMatch(node) {
 					p.controls.Wake.Dispatch()(p.common.triggers.wake.Description())
 					p.transition(enums.HibernationActive)
@@ -87,7 +87,7 @@ func (p *simple) create() hibernateStates {
 		},
 
 		enums.HibernationActive: state{
-			next: func(node *core.Node, _ types.Inspection) (bool, error) {
+			next: func(_ core.Servant, node *core.Node, _ types.Inspection) (bool, error) {
 				if p.common.triggers.sleep.IsMatch(node) {
 					p.controls.Sleep.Dispatch()(p.common.triggers.sleep.Description())
 					p.transition(enums.HibernationRetired)
@@ -103,7 +103,7 @@ func (p *simple) create() hibernateStates {
 		},
 
 		enums.HibernationRetired: state{
-			next: func(_ *core.Node, _ types.Inspection) (bool, error) {
+			next: func(_ core.Servant, _ *core.Node, _ types.Inspection) (bool, error) {
 				return false, fs.SkipAll
 			},
 		},

--- a/internal/feat/hiber/hibernate_test.go
+++ b/internal/feat/hiber/hibernate_test.go
@@ -47,7 +47,8 @@ var _ = Describe("feature", Ordered, func() {
 						&tv.Using{
 							Tree:         path,
 							Subscription: enums.SubscribeFolders,
-							Handler: func(node *core.Node) error {
+							Handler: func(servant tv.Servant) error {
+								node := servant.Node()
 								GinkgoWriter.Printf(
 									"---> 🍯 EXAMPLE-HIBERNATE-CALLBACK: '%v'\n", node.Path,
 								)
@@ -116,7 +117,8 @@ var _ = Describe("feature", Ordered, func() {
 				entry.NaviTE.Relative,
 			)
 
-			client := func(node *tv.Node) error {
+			client := func(servant tv.Servant) error {
+				node := servant.Node()
 				GinkgoWriter.Printf(
 					"---> 🌊 HIBERNATE-CALLBACK: '%v'\n", node.Path,
 				)

--- a/internal/feat/hiber/with-filter_test.go
+++ b/internal/feat/hiber/with-filter_test.go
@@ -118,7 +118,8 @@ var _ = Describe("feature", Ordered, func() {
 				Given:        "File Subscription",
 				Should:       "wake, then apply filter until the end",
 				Subscription: enums.SubscribeFiles,
-				Callback: func(node *core.Node) error {
+				Callback: func(servant tv.Servant) error {
+					node := servant.Node()
 					GinkgoWriter.Printf("---> WAKE-HIBERNATE-AND-FILTER-😵‍💫: '%v'\n", node.Path)
 
 					return nil
@@ -142,7 +143,8 @@ var _ = Describe("feature", Ordered, func() {
 				Given:        "File Subscription",
 				Should:       "apply filter until sleep",
 				Subscription: enums.SubscribeFiles,
-				Callback: func(node *core.Node) error {
+				Callback: func(servant tv.Servant) error {
+					node := servant.Node()
 					GinkgoWriter.Printf("---> SLEEP-HIBERNATE-AND-FILTER-😴: '%v'\n", node.Path)
 
 					return nil
@@ -166,7 +168,8 @@ var _ = Describe("feature", Ordered, func() {
 				Given:        "File Subscription",
 				Should:       "apply filter within hibernation range",
 				Subscription: enums.SubscribeFiles,
-				Callback: func(node *core.Node) error {
+				Callback: func(servant tv.Servant) error {
+					node := servant.Node()
 					GinkgoWriter.Printf("---> WAKE/SLEEP-HIBERNATE-AND-FILTER-😴: '%v'\n", node.Path)
 
 					return nil

--- a/internal/feat/nanny/nanny-plugin.go
+++ b/internal/feat/nanny/nanny-plugin.go
@@ -33,9 +33,10 @@ type plugin struct {
 	crate measure.Crate
 }
 
-func (p *plugin) Next(node *core.Node,
+func (p *plugin) Next(servant core.Servant,
 	inspection types.Inspection,
 ) (bool, error) {
+	node := servant.Node()
 	files := inspection.Sort(enums.EntryTypeFile)
 	node.Children = files
 	p.crate.Mums[enums.MetricNoChildFilesFound].Times(uint(len(files)))

--- a/internal/feat/resume/resume-plugin.go
+++ b/internal/feat/resume/resume-plugin.go
@@ -16,8 +16,10 @@ type Plugin struct {
 	IfResult core.ResultCompletion
 }
 
-func (p *Plugin) Next(node *core.Node, inspection types.Inspection) (bool, error) {
-	_, _ = node, inspection
+func (p *Plugin) Next(servant core.Servant,
+	inspection types.Inspection,
+) (bool, error) {
+	_, _ = servant, inspection
 	// apply the wake filter
 
 	return true, nil

--- a/internal/feat/sampling/controller.go
+++ b/internal/feat/sampling/controller.go
@@ -20,7 +20,7 @@ func (p *controller) Role() enums.Role {
 	return enums.RoleSampler
 }
 
-func (p *controller) Next(_ *core.Node, _ types.Inspection) (bool, error) {
+func (p *controller) Next(_ core.Servant, _ types.Inspection) (bool, error) {
 	return true, nil
 }
 

--- a/internal/feat/sampling/navigator-sample_test.go
+++ b/internal/feat/sampling/navigator-sample_test.go
@@ -46,7 +46,8 @@ var _ = Describe("feature", Ordered, func() {
 					&tv.Using{
 						Tree:         path,
 						Subscription: enums.SubscribeUniversal,
-						Handler: func(node *core.Node) error {
+						Handler: func(servant tv.Servant) error {
+							node := servant.Node()
 							GinkgoWriter.Printf(
 								"---> 🍯 EXAMPLE-SAMPLE-CALLBACK: '%v'\n", node.Path,
 							)
@@ -92,7 +93,8 @@ var _ = Describe("feature", Ordered, func() {
 				entry.NaviTE.Relative,
 			)
 
-			callback := func(node *tv.Node) error {
+			callback := func(servant tv.Servant) error {
+				node := servant.Node()
 				GinkgoWriter.Printf(
 					"---> 🌊 SAMPLE-CALLBACK: '%v'\n", node.Path,
 				)

--- a/internal/filtering/filter-custom_test.go
+++ b/internal/filtering/filter-custom_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 	"github.com/snivilised/li18ngo"
 	tv "github.com/snivilised/traverse"
-	"github.com/snivilised/traverse/core"
 	"github.com/snivilised/traverse/enums"
 	lab "github.com/snivilised/traverse/internal/laboratory"
 	"github.com/snivilised/traverse/internal/services"
@@ -48,22 +47,23 @@ var _ = Describe("NavigatorFilterCustom", Ordered, func() {
 			}
 
 			path := entry.Relative
-			callback := func(item *core.Node) error {
-				indicator := lo.Ternary(item.IsDirectory(), "📁", "💠")
+			callback := func(servant tv.Servant) error {
+				node := servant.Node()
+				indicator := lo.Ternary(node.IsDirectory(), "📁", "💠")
 				GinkgoWriter.Printf(
-					"===> %v Glob Filter(%v) source: '%v', item-name: '%v', item-scope(fs): '%v(%v)'\n",
+					"===> %v Glob Filter(%v) source: '%v', node-name: '%v', node-scope(fs): '%v(%v)'\n",
 					indicator,
 					customFilter.Description(),
 					customFilter.Source(),
-					item.Extension.Name,
-					item.Extension.Scope,
+					node.Extension.Name,
+					node.Extension.Scope,
 					customFilter.Scope(),
 				)
-				if lo.Contains(entry.Mandatory, item.Extension.Name) {
-					Expect(item).Should(MatchCurrentCustomFilter(customFilter))
+				if lo.Contains(entry.Mandatory, node.Extension.Name) {
+					Expect(node).Should(MatchCurrentCustomFilter(customFilter))
 				}
 
-				recording[item.Extension.Name] = len(item.Children)
+				recording[node.Extension.Name] = len(node.Children)
 				return nil
 			}
 			result, err := tv.Walk().Configure().Extent(tv.Prime(

--- a/internal/filtering/filter-extended-glob_test.go
+++ b/internal/filtering/filter-extended-glob_test.go
@@ -54,7 +54,8 @@ var _ = Describe("filtering", Ordered, func() {
 						&tv.Using{
 							Tree:         path,
 							Subscription: enums.SubscribeUniversal,
-							Handler: func(node *core.Node) error {
+							Handler: func(servant tv.Servant) error {
+								node := servant.Node()
 								GinkgoWriter.Printf(
 									"---> 🍯 EXAMPLE-EXTENDED-GLOB-FILTER-CALLBACK: '%v'\n", node.Path,
 								)
@@ -101,10 +102,11 @@ var _ = Describe("filtering", Ordered, func() {
 			}
 
 			path := entry.Relative
-			callback := func(node *core.Node) error {
+			callback := func(servant tv.Servant) error {
+				node := servant.Node()
 				indicator := lo.Ternary(node.IsDirectory(), "📁", "💠")
 				GinkgoWriter.Printf(
-					"===> %v Glob Filter(%v) source: '%v', item-name: '%v', item-scope(fs): '%v(%v)'\n",
+					"===> %v Glob Filter(%v) source: '%v', node-name: '%v', node-scope(fs): '%v(%v)'\n",
 					indicator,
 					traverseFilter.Description(),
 					traverseFilter.Source(),

--- a/internal/filtering/filter-glob_test.go
+++ b/internal/filtering/filter-glob_test.go
@@ -55,7 +55,8 @@ var _ = Describe("NavigatorFilterGlob", Ordered, func() {
 						&tv.Using{
 							Tree:         path,
 							Subscription: enums.SubscribeUniversal,
-							Handler: func(node *core.Node) error {
+							Handler: func(servant tv.Servant) error {
+								node := servant.Node()
 								GinkgoWriter.Printf(
 									"---> 🍯 EXAMPLE-GLOB-FILTER-CALLBACK: '%v'\n", node.Path,
 								)
@@ -102,10 +103,11 @@ var _ = Describe("NavigatorFilterGlob", Ordered, func() {
 			}
 
 			path := entry.Relative
-			callback := func(node *core.Node) error {
+			callback := func(servant tv.Servant) error {
+				node := servant.Node()
 				indicator := lo.Ternary(node.IsDirectory(), "📁", "💠")
 				GinkgoWriter.Printf(
-					"===> %v Glob Filter(%v) source: '%v', item-name: '%v', item-scope(fs): '%v(%v)'\n",
+					"===> %v Glob Filter(%v) source: '%v', node-name: '%v', node-scope(fs): '%v(%v)'\n",
 					indicator,
 					traverseFilter.Description(),
 					traverseFilter.Source(),

--- a/internal/filtering/filter-hybrid_test.go
+++ b/internal/filtering/filter-hybrid_test.go
@@ -60,20 +60,21 @@ var _ = Describe("feature", Ordered, func() {
 			}
 
 			path := entry.Relative
-			callback := func(item *core.Node) error {
-				actualNoChildren := len(item.Children)
+			callback := func(servant tv.Servant) error {
+				node := servant.Node()
+				actualNoChildren := len(node.Children)
 				GinkgoWriter.Printf(
 					"===> 💠 Child Glob Filter(%v, children: %v)"+
 						"source: '%v', node-name: '%v', node-scope: '%v', depth: '%v'\n",
 					childFilter.Description(),
 					actualNoChildren,
 					childFilter.Source(),
-					item.Extension.Name,
-					item.Extension.Scope,
-					item.Extension.Depth,
+					node.Extension.Name,
+					node.Extension.Scope,
+					node.Extension.Depth,
 				)
 
-				recording[item.Extension.Name] = len(item.Children)
+				recording[node.Extension.Name] = len(node.Children)
 				return nil
 			}
 

--- a/internal/filtering/filter-poly_test.go
+++ b/internal/filtering/filter-poly_test.go
@@ -67,7 +67,8 @@ var _ = Describe("feature", Ordered, func() {
 						&tv.Using{
 							Tree:         path,
 							Subscription: enums.SubscribeUniversal,
-							Handler: func(node *core.Node) error {
+							Handler: func(servant tv.Servant) error {
+								node := servant.Node()
 								GinkgoWriter.Printf(
 									"---> 🍯 EXAMPLE-POLY-FILTER-CALLBACK: '%v'\n", node.Path,
 								)
@@ -113,10 +114,11 @@ var _ = Describe("feature", Ordered, func() {
 			}
 
 			path := entry.Relative
-			callback := func(node *core.Node) error {
+			callback := func(servant tv.Servant) error {
+				node := servant.Node()
 				indicator := lo.Ternary(node.IsDirectory(), "📁", "💠")
 				GinkgoWriter.Printf(
-					"===> %v Poly Filter(%v) source: '%v', item-name: '%v', item-scope(fs): '%v(%v)'\n",
+					"===> %v Poly Filter(%v) source: '%v', node-name: '%v', node-scope(fs): '%v(%v)'\n",
 					indicator,
 					traverseFilter.Description(),
 					traverseFilter.Source(),

--- a/internal/filtering/filter-regex_test.go
+++ b/internal/filtering/filter-regex_test.go
@@ -54,7 +54,8 @@ var _ = Describe("feature", Ordered, func() {
 						&tv.Using{
 							Tree:         path,
 							Subscription: enums.SubscribeUniversal,
-							Handler: func(node *core.Node) error {
+							Handler: func(servant tv.Servant) error {
+								node := servant.Node()
 								GinkgoWriter.Printf(
 									"---> 🍯 EXAMPLE-REGEX-FILTER-CALLBACK: '%v'\n", node.Path,
 								)
@@ -101,22 +102,23 @@ var _ = Describe("feature", Ordered, func() {
 			}
 
 			path := entry.Relative
-			callback := func(item *core.Node) error {
-				indicator := lo.Ternary(item.IsDirectory(), "📁", "💠")
+			callback := func(servant tv.Servant) error {
+				node := servant.Node()
+				indicator := lo.Ternary(node.IsDirectory(), "📁", "💠")
 				GinkgoWriter.Printf(
-					"===> %v Glob Filter(%v) source: '%v', item-name: '%v', item-scope(fs): '%v(%v)'\n",
+					"===> %v Glob Filter(%v) source: '%v', node-name: '%v', node-scope(fs): '%v(%v)'\n",
 					indicator,
 					traverseFilter.Description(),
 					traverseFilter.Source(),
-					item.Extension.Name,
-					item.Extension.Scope,
+					node.Extension.Name,
+					node.Extension.Scope,
 					traverseFilter.Scope(),
 				)
-				if lo.Contains(entry.Mandatory, item.Extension.Name) {
-					Expect(item).Should(MatchCurrentRegexFilter(traverseFilter))
+				if lo.Contains(entry.Mandatory, node.Extension.Name) {
+					Expect(node).Should(MatchCurrentRegexFilter(traverseFilter))
 				}
 
-				recording[item.Extension.Name] = len(item.Children)
+				recording[node.Extension.Name] = len(node.Children)
 				return nil
 			}
 			result, err := tv.Walk().Configure().Extent(tv.Prime(

--- a/internal/filtering/matchers_test.go
+++ b/internal/filtering/matchers_test.go
@@ -22,9 +22,9 @@ func MatchCurrentRegexFilter(expected interface{}) GomegaMatcher {
 }
 
 func (m *IsCurrentRegexMatchMatcher) Match(actual interface{}) (bool, error) {
-	item, itemOk := actual.(*core.Node)
+	node, itemOk := actual.(*core.Node)
 	if !itemOk {
-		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", item)
+		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", node)
 	}
 
 	rxFilter, filterOk := m.rxFilter.(*filtering.RegExpr)
@@ -32,24 +32,24 @@ func (m *IsCurrentRegexMatchMatcher) Match(actual interface{}) (bool, error) {
 		return false, fmt.Errorf("matcher expected a *RegexFilter (%T)", rxFilter)
 	}
 
-	return rxFilter.IsMatch(item), nil
+	return rxFilter.IsMatch(node), nil
 }
 
 func (m *IsCurrentRegexMatchMatcher) FailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	rxFilter, _ := m.rxFilter.(*filtering.RegExpr)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nto match regex\n\t%v\n",
-		item.Extension.Name, rxFilter.Source(),
+		node.Extension.Name, rxFilter.Source(),
 	)
 }
 
 func (m *IsCurrentRegexMatchMatcher) NegatedFailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	rxFilter, _ := m.rxFilter.(*filtering.RegExpr)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nNOT to match regex\n\t%v\n",
-		item.Extension.Name, rxFilter.Source(),
+		node.Extension.Name, rxFilter.Source(),
 	)
 }
 
@@ -67,9 +67,9 @@ func MatchCurrentGlobFilter(expected interface{}) GomegaMatcher {
 }
 
 func (m *IsCurrentGlobMatchMatcher) Match(actual interface{}) (bool, error) {
-	item, itemOk := actual.(*core.Node)
+	node, itemOk := actual.(*core.Node)
 	if !itemOk {
-		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", item)
+		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", node)
 	}
 
 	gbFilter, filterOk := m.gbFilter.(*filtering.Glob)
@@ -77,24 +77,24 @@ func (m *IsCurrentGlobMatchMatcher) Match(actual interface{}) (bool, error) {
 		return false, fmt.Errorf("matcher expected a *GlobFilter (%T)", gbFilter)
 	}
 
-	return gbFilter.IsMatch(item), nil
+	return gbFilter.IsMatch(node), nil
 }
 
 func (m *IsCurrentGlobMatchMatcher) FailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	gbFilter, _ := m.gbFilter.(*filtering.Glob)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nto match glob\n\t%v\n",
-		item.Extension.Name, gbFilter.Source(),
+		node.Extension.Name, gbFilter.Source(),
 	)
 }
 
 func (m *IsCurrentGlobMatchMatcher) NegatedFailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	gbFilter, _ := m.gbFilter.(*filtering.Glob)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nNOT to match glob\n\t%v\n",
-		item.Extension.Name, gbFilter.Source(),
+		node.Extension.Name, gbFilter.Source(),
 	)
 }
 
@@ -112,9 +112,9 @@ func MatchCurrentExtendedFilter(expected interface{}) GomegaMatcher {
 }
 
 func (m *IsCurrentExtendedGlobMatchMatcher) Match(actual interface{}) (bool, error) {
-	item, itemOk := actual.(*core.Node)
+	node, itemOk := actual.(*core.Node)
 	if !itemOk {
-		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", item)
+		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", node)
 	}
 
 	egbFilter, filterOk := m.egbFilter.(*filtering.ExtendedGlob)
@@ -122,24 +122,24 @@ func (m *IsCurrentExtendedGlobMatchMatcher) Match(actual interface{}) (bool, err
 		return false, fmt.Errorf("matcher expected a *IncaseFilter (%T)", egbFilter)
 	}
 
-	return egbFilter.IsMatch(item), nil
+	return egbFilter.IsMatch(node), nil
 }
 
 func (m *IsCurrentExtendedGlobMatchMatcher) FailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	egbFilter, _ := m.egbFilter.(*filtering.ExtendedGlob)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nto match incase\n\t%v\n",
-		item.Extension.Name, egbFilter.Source(),
+		node.Extension.Name, egbFilter.Source(),
 	)
 }
 
 func (m *IsCurrentExtendedGlobMatchMatcher) NegatedFailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	egbFilter, _ := m.egbFilter.(*filtering.ExtendedGlob)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nNOT to match incase\n\t%v\n",
-		item.Extension.Name, egbFilter.Source(),
+		node.Extension.Name, egbFilter.Source(),
 	)
 }
 
@@ -157,9 +157,9 @@ func MatchCurrentCustomFilter(expected interface{}) GomegaMatcher {
 }
 
 func (m *IsCurrentCustomMatchMatcher) Match(actual interface{}) (bool, error) {
-	item, itemOk := actual.(*core.Node)
+	node, itemOk := actual.(*core.Node)
 	if !itemOk {
-		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", item)
+		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", node)
 	}
 
 	tvFilter, filterOk := m.tvFilter.(core.TraverseFilter)
@@ -167,23 +167,23 @@ func (m *IsCurrentCustomMatchMatcher) Match(actual interface{}) (bool, error) {
 		return false, fmt.Errorf("matcher expected a core.TraverseFilter (%T)", tvFilter)
 	}
 
-	return tvFilter.IsMatch(item), nil
+	return tvFilter.IsMatch(node), nil
 }
 
 func (m *IsCurrentCustomMatchMatcher) FailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	tvFilter, _ := m.tvFilter.(core.TraverseFilter)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nto match custom filter\n\t%v\n",
-		item.Extension.Name, tvFilter.Source(),
+		node.Extension.Name, tvFilter.Source(),
 	)
 }
 
 func (m *IsCurrentCustomMatchMatcher) NegatedFailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	tvFilter, _ := m.tvFilter.(core.TraverseFilter)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nNOT to match custom filter\n\t%v\n",
-		item.Extension.Name, tvFilter.Source(),
+		node.Extension.Name, tvFilter.Source(),
 	)
 }

--- a/internal/kernel/gomega-matchers_test.go
+++ b/internal/kernel/gomega-matchers_test.go
@@ -22,9 +22,9 @@ func MatchCurrentRegexFilter(expected interface{}) GomegaMatcher {
 }
 
 func (m *IsCurrentRegexMatchMatcher) Match(actual interface{}) (bool, error) {
-	item, itemOk := actual.(*core.Node)
+	node, itemOk := actual.(*core.Node)
 	if !itemOk {
-		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", item)
+		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", node)
 	}
 
 	rxFilter, filterOk := m.rxFilter.(*filtering.RegExpr)
@@ -32,24 +32,24 @@ func (m *IsCurrentRegexMatchMatcher) Match(actual interface{}) (bool, error) {
 		return false, fmt.Errorf("matcher expected a *RegexFilter (%T)", rxFilter)
 	}
 
-	return rxFilter.IsMatch(item), nil
+	return rxFilter.IsMatch(node), nil
 }
 
 func (m *IsCurrentRegexMatchMatcher) FailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	rxFilter, _ := m.rxFilter.(*filtering.RegExpr)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nto match regex\n\t%v\n",
-		item.Extension.Name, rxFilter.Source(),
+		node.Extension.Name, rxFilter.Source(),
 	)
 }
 
 func (m *IsCurrentRegexMatchMatcher) NegatedFailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	rxFilter, _ := m.rxFilter.(*filtering.RegExpr)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nNOT to match regex\n\t%v\n",
-		item.Extension.Name, rxFilter.Source(),
+		node.Extension.Name, rxFilter.Source(),
 	)
 }
 
@@ -67,9 +67,9 @@ func MatchCurrentGlobFilter(expected interface{}) GomegaMatcher {
 }
 
 func (m *IsCurrentGlobMatchMatcher) Match(actual interface{}) (bool, error) {
-	item, itemOk := actual.(*core.Node)
+	node, itemOk := actual.(*core.Node)
 	if !itemOk {
-		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", item)
+		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", node)
 	}
 
 	gbFilter, filterOk := m.gbFilter.(*filtering.Glob)
@@ -77,24 +77,24 @@ func (m *IsCurrentGlobMatchMatcher) Match(actual interface{}) (bool, error) {
 		return false, fmt.Errorf("matcher expected a *GlobFilter (%T)", gbFilter)
 	}
 
-	return gbFilter.IsMatch(item), nil
+	return gbFilter.IsMatch(node), nil
 }
 
 func (m *IsCurrentGlobMatchMatcher) FailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	gbFilter, _ := m.gbFilter.(*filtering.Glob)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nto match glob\n\t%v\n",
-		item.Extension.Name, gbFilter.Source(),
+		node.Extension.Name, gbFilter.Source(),
 	)
 }
 
 func (m *IsCurrentGlobMatchMatcher) NegatedFailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	gbFilter, _ := m.gbFilter.(*filtering.Glob)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nNOT to match glob\n\t%v\n",
-		item.Extension.Name, gbFilter.Source(),
+		node.Extension.Name, gbFilter.Source(),
 	)
 }
 
@@ -112,9 +112,9 @@ func MatchCurrentExtendedFilter(expected interface{}) GomegaMatcher {
 }
 
 func (m *IsCurrentExtendedGlobMatchMatcher) Match(actual interface{}) (bool, error) {
-	item, itemOk := actual.(*core.Node)
+	node, itemOk := actual.(*core.Node)
 	if !itemOk {
-		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", item)
+		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", node)
 	}
 
 	egbFilter, filterOk := m.egbFilter.(*filtering.ExtendedGlob)
@@ -122,24 +122,24 @@ func (m *IsCurrentExtendedGlobMatchMatcher) Match(actual interface{}) (bool, err
 		return false, fmt.Errorf("matcher expected a *IncaseFilter (%T)", egbFilter)
 	}
 
-	return egbFilter.IsMatch(item), nil
+	return egbFilter.IsMatch(node), nil
 }
 
 func (m *IsCurrentExtendedGlobMatchMatcher) FailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	egbFilter, _ := m.egbFilter.(*filtering.ExtendedGlob)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nto match incase\n\t%v\n",
-		item.Extension.Name, egbFilter.Source(),
+		node.Extension.Name, egbFilter.Source(),
 	)
 }
 
 func (m *IsCurrentExtendedGlobMatchMatcher) NegatedFailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	egbFilter, _ := m.egbFilter.(*filtering.ExtendedGlob)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nNOT to match incase\n\t%v\n",
-		item.Extension.Name, egbFilter.Source(),
+		node.Extension.Name, egbFilter.Source(),
 	)
 }
 
@@ -157,9 +157,9 @@ func MatchCurrentCustomFilter(expected interface{}) GomegaMatcher {
 }
 
 func (m *IsCurrentCustomMatchMatcher) Match(actual interface{}) (bool, error) {
-	item, itemOk := actual.(*core.Node)
+	node, itemOk := actual.(*core.Node)
 	if !itemOk {
-		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", item)
+		return false, fmt.Errorf("matcher expected a *TraverseItem (%T)", node)
 	}
 
 	tvFilter, filterOk := m.tvFilter.(core.TraverseFilter)
@@ -167,23 +167,23 @@ func (m *IsCurrentCustomMatchMatcher) Match(actual interface{}) (bool, error) {
 		return false, fmt.Errorf("matcher expected a core.TraverseFilter (%T)", tvFilter)
 	}
 
-	return tvFilter.IsMatch(item), nil
+	return tvFilter.IsMatch(node), nil
 }
 
 func (m *IsCurrentCustomMatchMatcher) FailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	tvFilter, _ := m.tvFilter.(core.TraverseFilter)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nto match custom filter\n\t%v\n",
-		item.Extension.Name, tvFilter.Source(),
+		node.Extension.Name, tvFilter.Source(),
 	)
 }
 
 func (m *IsCurrentCustomMatchMatcher) NegatedFailureMessage(actual interface{}) string {
-	item, _ := actual.(*core.Node)
+	node, _ := actual.(*core.Node)
 	tvFilter, _ := m.tvFilter.(core.TraverseFilter)
 
 	return fmt.Sprintf("🔥 Expected\n\t%v\nNOT to match custom filter\n\t%v\n",
-		item.Extension.Name, tvFilter.Source(),
+		node.Extension.Name, tvFilter.Source(),
 	)
 }

--- a/internal/kernel/kernel-defs.go
+++ b/internal/kernel/kernel-defs.go
@@ -27,7 +27,7 @@ type (
 		// Traverse
 		Traverse(ctx context.Context,
 			ns *navigationStatic,
-			current *core.Node,
+			servant core.Servant,
 		) (bool, error)
 
 		// Result
@@ -89,7 +89,7 @@ type (
 
 	// Invokable
 	Invokable interface {
-		Invoke(node *core.Node, inspection types.Inspection) error
+		Invoke(servant core.Servant, inspection types.Inspection) error
 	}
 
 	// Mutant represents the mutable interface to the Guardian
@@ -185,8 +185,10 @@ func (v *navigationVapour) AssignChildren(children []fs.DirEntry) {
 	v.present.Children = children
 }
 
-type NodeInvoker func(node *core.Node, inspection types.Inspection) error
+type NodeInvoker func(servant core.Servant, inspection types.Inspection) error
 
-func (fn NodeInvoker) Invoke(node *core.Node, inspection types.Inspection) error {
-	return fn(node, inspection)
+func (fn NodeInvoker) Invoke(servant core.Servant,
+	inspection types.Inspection,
+) error {
+	return fn(servant, inspection)
 }

--- a/internal/kernel/mediator.go
+++ b/internal/kernel/mediator.go
@@ -125,8 +125,8 @@ func (m *mediator) Spawn(ctx context.Context, tree string) (core.TraverseResult,
 	})
 }
 
-func (m *mediator) Invoke(node *core.Node, inspection types.Inspection) error {
-	return m.guardian.Invoke(node, inspection)
+func (m *mediator) Invoke(servant core.Servant, inspection types.Inspection) error {
+	return m.guardian.Invoke(servant, inspection)
 }
 
 func (m *mediator) Supervisor() *measure.Supervisor {

--- a/internal/kernel/navigator-agent.go
+++ b/internal/kernel/navigator-agent.go
@@ -60,7 +60,9 @@ func (n *navigatorAgent) top(ctx context.Context,
 		},
 		func() error {
 			_, te := ns.mediator.impl.Traverse(ctx, ns,
-				core.Top(ns.tree, info),
+				servant{
+					node: core.Top(ns.tree, info),
+				},
 			)
 
 			return te
@@ -68,13 +70,6 @@ func (n *navigatorAgent) top(ctx context.Context,
 	)
 
 	return ns.mediator.impl.Result(ctx, err), err
-}
-
-func (n *navigatorAgent) Traverse(context.Context,
-	*navigationStatic,
-	*core.Node,
-) (bool, error) {
-	return continueTraversal, nil
 }
 
 // Result is the single point at which a Result is constructed. Due to
@@ -128,18 +123,18 @@ func (n *navigatorAgent) travel(ctx context.Context,
 
 		// TODO: check sampling; should happen transparently, by plugin
 
-		current := core.New(
-			path,
-			entry,
-			info,
-			parent,
-			e,
-		)
-
 		// TODO: ok for Travel to by-pass mediator?
 		//
 		if progress, err := ns.mediator.impl.Traverse(
-			ctx, ns, current,
+			ctx, ns, servant{
+				node: core.New(
+					path,
+					entry,
+					info,
+					parent,
+					e,
+				),
+			},
 		); !progress {
 			if err != nil {
 				if errors.Is(err, fs.SkipDir) {
@@ -148,7 +143,7 @@ func (n *navigatorAgent) travel(ctx context.Context,
 					// skipTraversal, what we're saying is that we want to skip
 					// processing all successive siblings but continue traversal.
 					// The !progress indicates we're skipping the remaining
-					// processing of all of the parent item's remaining children.
+					// processing of all of the parent node's remaining children.
 					// (see the ✨ below ...)
 					//
 					return skipTraversal, err

--- a/internal/kernel/navigator-files.go
+++ b/internal/kernel/navigator-files.go
@@ -20,8 +20,9 @@ func (n *navigatorFiles) Top(ctx context.Context,
 
 func (n *navigatorFiles) Traverse(ctx context.Context,
 	ns *navigationStatic,
-	current *core.Node,
+	servant core.Servant,
 ) (bool, error) {
+	current := servant.Node()
 	descended := ns.mediator.descend(current)
 
 	defer func(permit bool) {
@@ -38,12 +39,12 @@ func (n *navigatorFiles) Traverse(ctx context.Context,
 	// this case, the client should use the OnDescend callback (yet to be implemented) and
 	// return SkipDir from there.
 	//
-	vapour, err := n.inspect(ns, current)
+	vapour, err := n.inspect(ns, servant)
 
 	if !current.IsDirectory() {
 		// Effectively, this is the file only filter
 		//
-		return false, ns.mediator.Invoke(current, vapour)
+		return false, ns.mediator.Invoke(servant, vapour)
 	}
 
 	if skip, e := ns.mediator.o.Defects.Skip.Ask(
@@ -58,10 +59,11 @@ func (n *navigatorFiles) Traverse(ctx context.Context,
 }
 
 func (n *navigatorFiles) inspect(ns *navigationStatic,
-	current *core.Node,
+	servant core.Servant,
 ) (inspection, error) {
 	var (
-		vapour = &navigationVapour{
+		current = servant.Node()
+		vapour  = &navigationVapour{
 			ns:      ns,
 			present: current,
 		}

--- a/internal/kernel/navigator-files_test.go
+++ b/internal/kernel/navigator-files_test.go
@@ -40,7 +40,7 @@ var _ = Describe("NavigatorFiles", Ordered, func() {
 					&tv.Using{
 						Tree:         RootPath,
 						Subscription: tv.SubscribeFiles,
-						Handler: func(_ *tv.Node) error {
+						Handler: func(_ tv.Servant) error {
 							return nil
 						},
 					},

--- a/internal/kernel/navigator-folders-with-files_test.go
+++ b/internal/kernel/navigator-folders-with-files_test.go
@@ -46,12 +46,13 @@ var _ = Describe("NavigatorFoldersWithFiles", Ordered, func() {
 		DescribeTable("Filter Children (glob)",
 			func(ctx SpecContext, entry *lab.FilterTE) {
 				recording := make(lab.RecordingMap)
-				once := func(node *tv.Node) error {
+				once := func(servant tv.Servant) error {
+					node := servant.Node()
 					_, found := recording[node.Extension.Name]
 					Expect(found).To(BeFalse())
 					recording[node.Extension.Name] = len(node.Children)
 
-					return entry.Callback(node)
+					return entry.Callback(servant)
 				}
 				path := entry.Relative
 				result, err := tv.Walk().Configure().Extent(tv.Prime(

--- a/internal/kernel/navigator-folders.go
+++ b/internal/kernel/navigator-folders.go
@@ -20,8 +20,9 @@ func (n *navigatorFolders) Top(ctx context.Context,
 
 func (n *navigatorFolders) Traverse(ctx context.Context,
 	ns *navigationStatic,
-	current *core.Node,
+	servant core.Servant,
 ) (bool, error) {
+	current := servant.Node()
 	descended := ns.mediator.descend(current)
 
 	defer func(permit bool) {
@@ -32,9 +33,9 @@ func (n *navigatorFolders) Traverse(ctx context.Context,
 		return continueTraversal, nil
 	}
 
-	vapour, err := n.inspect(ns, current)
+	vapour, err := n.inspect(ns, servant)
 
-	if e := ns.mediator.Invoke(current, vapour); e != nil {
+	if e := ns.mediator.Invoke(servant, vapour); e != nil {
 		return continueTraversal, e
 	}
 
@@ -48,10 +49,11 @@ func (n *navigatorFolders) Traverse(ctx context.Context,
 }
 
 func (n *navigatorFolders) inspect(ns *navigationStatic,
-	current *core.Node,
+	servant core.Servant,
 ) (inspection, error) {
 	var (
-		vapour = &navigationVapour{
+		current = servant.Node()
+		vapour  = &navigationVapour{
 			ns:      ns,
 			present: current,
 		}

--- a/internal/kernel/navigator-simple_test.go
+++ b/internal/kernel/navigator-simple_test.go
@@ -48,16 +48,17 @@ var _ = Describe("NavigatorUniversal", Ordered, func() {
 	DescribeTable("Ensure Callback Invoked Once", Label("simple"),
 		func(ctx SpecContext, entry *lab.NaviTE) {
 			recording := make(lab.RecordingMap)
-			once := func(node *tv.Node) error {
+			once := func(servant tv.Servant) error {
+				node := servant.Node()
 				_, found := recording[node.Path] // TODO: should this be name not path?
 				Expect(found).To(BeFalse())
 				recording[node.Path] = len(node.Children)
 
-				return entry.Callback(node)
+				return entry.Callback(servant)
 			}
 
-			visitor := func(node *tv.Node) error {
-				return once(node)
+			visitor := func(servant tv.Servant) error {
+				return once(servant)
 			}
 
 			callback := lo.Ternary(entry.Once, once,

--- a/internal/kernel/navigator-universal.go
+++ b/internal/kernel/navigator-universal.go
@@ -20,8 +20,9 @@ func (n *navigatorUniversal) Top(ctx context.Context,
 
 func (n *navigatorUniversal) Traverse(ctx context.Context,
 	ns *navigationStatic,
-	current *core.Node,
+	servant core.Servant,
 ) (bool, error) {
+	current := servant.Node()
 	descended := ns.mediator.descend(current)
 
 	defer func(permit bool) {
@@ -32,9 +33,9 @@ func (n *navigatorUniversal) Traverse(ctx context.Context,
 		return continueTraversal, nil
 	}
 
-	vapour, err := n.inspect(ns, current)
+	vapour, err := n.inspect(ns, servant)
 
-	if e := ns.mediator.Invoke(current, vapour); e != nil {
+	if e := ns.mediator.Invoke(servant, vapour); e != nil {
 		return continueTraversal, e
 	}
 
@@ -50,10 +51,11 @@ func (n *navigatorUniversal) Traverse(ctx context.Context,
 }
 
 func (n *navigatorUniversal) inspect(ns *navigationStatic,
-	current *core.Node,
+	servant core.Servant,
 ) (inspection, error) {
 	var (
-		vapour = &navigationVapour{
+		current = servant.Node()
+		vapour  = &navigationVapour{
 			ns:      ns,
 			present: current,
 		}

--- a/internal/kernel/servant.go
+++ b/internal/kernel/servant.go
@@ -1,0 +1,15 @@
+package kernel
+
+import (
+	"github.com/snivilised/traverse/core"
+)
+
+type (
+	servant struct {
+		node *core.Node
+	}
+)
+
+func (s servant) Node() *core.Node {
+	return s.node
+}

--- a/internal/laboratory/callbacks.go
+++ b/internal/laboratory/callbacks.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,stylecheck // ok
 	. "github.com/onsi/gomega"    //nolint:revive,stylecheck // ok
+	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
 	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/internal/third/lo"
@@ -28,7 +29,8 @@ func End(em string) cycle.EndHandler {
 }
 
 func UniversalCallback(name string) core.Client {
-	return func(node *core.Node) error {
+	return func(servant tv.Servant) error {
+		node := servant.Node()
 		depth := node.Extension.Depth
 		GinkgoWriter.Printf(
 			"---> 🌊 UNIVERSAL//%v-CALLBACK: (depth:%v) '%v'\n", name, depth, node.Path,
@@ -40,7 +42,8 @@ func UniversalCallback(name string) core.Client {
 }
 
 func FoldersCallback(name string) core.Client {
-	return func(node *core.Node) error {
+	return func(servant tv.Servant) error {
+		node := servant.Node()
 		depth := node.Extension.Depth
 		actualNoChildren := len(node.Children)
 		GinkgoWriter.Printf(
@@ -57,7 +60,8 @@ func FoldersCallback(name string) core.Client {
 }
 
 func FilesCallback(name string) core.Client {
-	return func(node *core.Node) error {
+	return func(servant tv.Servant) error {
+		node := servant.Node()
 		GinkgoWriter.Printf("---> 🌙 FILES//%v-CALLBACK: '%v'\n", name, node.Path)
 		Expect(node.IsDirectory()).To(BeFalse(),
 			Because(node.Path, "node expected to be file"),
@@ -71,7 +75,8 @@ func FilesCallback(name string) core.Client {
 func FoldersCaseSensitiveCallback(first, second string) core.Client {
 	recording := make(RecordingMap)
 
-	return func(node *core.Node) error {
+	return func(servant tv.Servant) error {
+		node := servant.Node()
 		recording[node.Path] = len(node.Children)
 
 		GinkgoWriter.Printf("---> 🔆 CASE-SENSITIVE-CALLBACK: '%v'\n", node.Path)

--- a/internal/laboratory/directory-tree-builder.go
+++ b/internal/laboratory/directory-tree-builder.go
@@ -19,18 +19,18 @@ const (
 	doWrite = true
 )
 
-func Musico(verbose bool, portions ...string) (tsys *TestTraverseFS, root string) {
-	tsys = &TestTraverseFS{
+func Musico(verbose bool, portions ...string) (fS *TestTraverseFS, root string) {
+	fS = &TestTraverseFS{
 		fstest.MapFS{},
 	}
 
 	root = Provision(
-		NewMemWriteProvider(tsys, os.ReadFile, portions...),
+		NewMemWriteProvider(fS, os.ReadFile, portions...),
 		verbose,
 		portions...,
 	)
 
-	return tsys, root
+	return fS, root
 }
 
 func Provision(provider *IOProvider, verbose bool, portions ...string) (root string) {

--- a/internal/laboratory/test-utilities.go
+++ b/internal/laboratory/test-utilities.go
@@ -33,11 +33,11 @@ func Normalise(p string) string {
 }
 
 func Because(name, because string) string {
-	return fmt.Sprintf("❌ for item named: '%v', because: '%v'", name, because)
+	return fmt.Sprintf("❌ for node named: '%v', because: '%v'", name, because)
 }
 
 func Reason(name string) string {
-	return fmt.Sprintf("❌ for item named: '%v'", name)
+	return fmt.Sprintf("❌ for node named: '%v'", name)
 }
 
 func Log() string {

--- a/internal/types/definitions.go
+++ b/internal/types/definitions.go
@@ -21,7 +21,7 @@ type (
 		// Next invokes this decorator which returns true if
 		// next link in the chain can be run or false to stop
 		// execution of subsequent links.
-		Next(node *core.Node, inspection Inspection) (bool, error)
+		Next(servant core.Servant, inspection Inspection) (bool, error)
 
 		// Role indicates the identity of the link
 		Role() enums.Role

--- a/locale/messages-errors.go
+++ b/locale/messages-errors.go
@@ -1,6 +1,8 @@
 package locale
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/nicksnyder/go-i18n/v2/i18n"
@@ -17,7 +19,7 @@ type FilterIsNilErrorTemplData struct {
 // Message
 func (td FilterIsNilErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "filter-is-nil.error",
+		ID:          "filter-is-nil.static-error",
 		Description: "filter is nil error",
 		Other:       "filter is nil",
 	}
@@ -43,7 +45,7 @@ type FilterMissingTypeErrorTemplData struct {
 // Message
 func (td FilterMissingTypeErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "filter-missing-type.error",
+		ID:          "filter-missing-type.static-error",
 		Description: "filter missing type",
 		Other:       "filter missing type",
 	}
@@ -69,7 +71,7 @@ type FilterCustomNotSupportedErrorTemplData struct {
 // Message
 func (td FilterCustomNotSupportedErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "custom-filter-not-supported-for-children.error",
+		ID:          "custom-filter-not-supported-for-children.static-error",
 		Description: "custom filter not supported for children",
 		Other:       "custom filter not supported for children",
 	}
@@ -95,7 +97,7 @@ type FilterUndefinedErrorTemplData struct {
 // Message
 func (td FilterUndefinedErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "filter-is-undefined.error",
+		ID:          "filter-is-undefined.static-error",
 		Description: "filter is undefined error",
 		Other:       "filter is undefined",
 	}
@@ -121,7 +123,7 @@ type InternalFailedToGetNavigatorDriverErrorTemplData struct {
 // Message
 func (td InternalFailedToGetNavigatorDriverErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "failed-to-get-navigator-driver.error",
+		ID:          "failed-to-get-navigator-driver.static-error",
 		Description: "failed to get navigator driver",
 		Other:       "failed to get navigator driver",
 	}
@@ -137,45 +139,68 @@ var ErrInternalFailedToGetNavigatorDriver = InternalFailedToGetNavigatorDriverEr
 	},
 }
 
-// ❌ InvalidIncaseFilterDef error
+// ❌ InvalidIncaseFilterDefError
 
-// InvalidIncaseFilterDefTemplData
-type InvalidIncaseFilterDefErrorTemplData struct {
+type InvalidIncaseFilterDefTemplData struct {
 	traverseTemplData
+	Pattern string
 }
 
-// Message
-func (td InvalidIncaseFilterDefErrorTemplData) Message() *i18n.Message {
+func (td InvalidIncaseFilterDefTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "invalid-incase-filter-definition.error",
-		Description: "invalid incase filter definition; pattern is missing separator",
-		Other:       "invalid incase filter definition; pattern is missing separator",
+		ID:          "invalid-incase-filter-definition.dynamic-error",
+		Description: "invalid incase filter definition; pattern is missing separator wrapper error",
+		Other:       "pattern: {{.Pattern}}",
 	}
 }
 
 type InvalidIncaseFilterDefError struct {
 	li18ngo.LocalisableError
+	Wrapped error
 }
 
-// IsInvalidIncaseFilterDefError uses errors.Is to check
-// if the err's error tree contains the core error:
-// InvalidIncaseFilterDefError
-func IsInvalidIncaseFilterDefError(err error) bool {
-	return errors.Is(err, errInvalidIncaseFilterDef)
+func (e InvalidIncaseFilterDefError) Error() string {
+	return fmt.Sprintf("%v, %v", e.Wrapped.Error(), li18ngo.Text(e.Data))
+}
+
+func (e InvalidIncaseFilterDefError) Unwrap() error {
+	return e.Wrapped
 }
 
 func NewInvalidIncaseFilterDefError(pattern string) error {
-	return errors.Wrap(
-		errInvalidIncaseFilterDef,
-		li18ngo.Text(PatternFieldTemplData{
-			Pattern: pattern,
-		}),
-	)
+	return &InvalidIncaseFilterDefError{
+		LocalisableError: li18ngo.LocalisableError{
+			Data: InvalidIncaseFilterDefTemplData{
+				Pattern: pattern,
+			},
+		},
+		Wrapped: errCoreInvalidIncaseFilterDef,
+	}
 }
 
-var errInvalidIncaseFilterDef = InvalidIncaseFilterDefError{
+type CoreInvalidIncaseFilterDefErrorTemplData struct {
+	traverseTemplData
+}
+
+func IsInvalidIncaseFilterDefError(err error) bool {
+	return errors.Is(err, errCoreInvalidIncaseFilterDef)
+}
+
+func (td CoreInvalidIncaseFilterDefErrorTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "invalid-incase-filter-definition.core-error",
+		Description: "invalid incase filter definition; pattern is missing separator core error",
+		Other:       "invalid incase filter definition; pattern is missing separator",
+	}
+}
+
+type CoreInvalidIncaseFilterDefError struct {
+	li18ngo.LocalisableError
+}
+
+var errCoreInvalidIncaseFilterDef = CoreInvalidIncaseFilterDefError{
 	LocalisableError: li18ngo.LocalisableError{
-		Data: InvalidIncaseFilterDefErrorTemplData{},
+		Data: CoreInvalidIncaseFilterDefErrorTemplData{},
 	},
 }
 
@@ -189,7 +214,7 @@ type WorkerPoolCreationFailedErrorTemplData struct {
 // Message
 func (td WorkerPoolCreationFailedErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "failed-to-create-worker-pool.error",
+		ID:          "failed-to-create-worker-pool.static-error",
 		Description: "failed to create worker pool",
 		Other:       "failed to create worker pool",
 	}
@@ -215,7 +240,7 @@ type InvalidFileSamplingSpecMissingFilesErrorTemplData struct {
 // Message
 func (td InvalidFileSamplingSpecMissingFilesErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "invalid-file-sampling-spec-missing-files.error",
+		ID:          "invalid-file-sampling-spec-missing-files.static-error",
 		Description: "invalid file sampling specification, missing no of files",
 		Other:       "invalid file sampling specification, missing no of files",
 	}
@@ -241,7 +266,7 @@ type InvalidFolderSamplingSpecMissingFoldersErrorTemplData struct {
 // Message
 func (td InvalidFolderSamplingSpecMissingFoldersErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "invalid-file-sampling-spec-missing-folders.error",
+		ID:          "invalid-file-sampling-spec-missing-folders.static-error",
 		Description: "invalid file sampling specification, missing no of folders",
 		Other:       "invalid file sampling specification, missing no of folders",
 	}
@@ -267,7 +292,7 @@ type MissingCustomFilterDefinitionErrorTemplData struct {
 // Message
 func (td MissingCustomFilterDefinitionErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "missing-custom-filter-definition.error",
+		ID:          "missing-custom-filter-definition.static-error",
 		Description: "config error missing-custom-filter-definition",
 		Other:       "missing custom filter definition (config error)",
 	}
@@ -282,10 +307,6 @@ var ErrMissingCustomFilterDefinition = MissingCustomFilterDefinitionError{
 		Data: MissingCustomFilterDefinitionErrorTemplData{},
 	},
 }
-
-// to define variable error with simple field - "Field and Variable error/fv18e"
-// "Simple i18n Field"
-// followed by
 
 // 🍀 Pattern
 
@@ -309,40 +330,72 @@ func (td PatternFieldTemplData) Message() *i18n.Message {
 // InvalidExtGlobFilterMissingSeparatorTemplData
 type InvalidExtGlobFilterMissingSeparatorErrorTemplData struct {
 	traverseTemplData
+	Pattern string
 }
 
 // Message
 func (td InvalidExtGlobFilterMissingSeparatorErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "invalid-extended-glob-filter-missing-separator.error",
+		ID:          "invalid-extended-glob-filter-missing-separator.dynamic-error",
 		Description: "invalid extended glob filter definition; pattern is missing separator",
-		Other:       "invalid extended glob filter definition; pattern is missing separator",
+		Other:       "pattern: {{.Pattern}}",
 	}
 }
 
 type InvalidExtGlobFilterMissingSeparatorError struct {
 	li18ngo.LocalisableError
+	Wrapped error
+}
+
+func (e InvalidExtGlobFilterMissingSeparatorError) Error() string {
+	return fmt.Sprintf("%v, %v", e.Wrapped.Error(), li18ngo.Text(e.Data))
+}
+
+func (e InvalidExtGlobFilterMissingSeparatorError) Unwrap() error {
+	return e.Wrapped
+}
+
+func NewInvalidExtGlobFilterMissingSeparatorError(pattern string) error {
+	return &InvalidExtGlobFilterMissingSeparatorError{
+		Wrapped: errCoreInvalidExtGlobFilterMissingSeparator,
+		LocalisableError: li18ngo.LocalisableError{
+			Data: InvalidExtGlobFilterMissingSeparatorErrorTemplData{
+				Pattern: pattern,
+			},
+		},
+	}
+}
+
+// ❌ CoreInvalidExtGlobFilterMissingSeparator
+
+// InvalidExtGlobFilterMissingSeparatorTemplData
+type CoreInvalidExtGlobFilterMissingSeparatorErrorTemplData struct {
+	traverseTemplData
 }
 
 // IsInvalidExtGlobFilterMissingSeparatorError uses errors.Is to check
 // if the err's error tree contains the core error:
-// InvalidExtGlobFilterMissingSeparatorError
+// CoreInvalidExtGlobFilterMissingSeparatorError
 func IsInvalidExtGlobFilterMissingSeparatorError(err error) bool {
-	return errors.Is(err, errInvalidExtGlobFilterMissingSeparator)
+	return errors.Is(err, errCoreInvalidExtGlobFilterMissingSeparator)
 }
 
-func NewInvalidExtGlobFilterMissingSeparatorError(pattern string) error {
-	return errors.Wrap(
-		errInvalidExtGlobFilterMissingSeparator,
-		li18ngo.Text(PatternFieldTemplData{
-			Pattern: pattern,
-		}),
-	)
+// Message
+func (td CoreInvalidExtGlobFilterMissingSeparatorErrorTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "invalid-extended-glob-filter-missing-separator.core-error",
+		Description: "invalid extended glob filter definition; pattern is missing separator",
+		Other:       "invalid extended glob filter definition; pattern is missing separator",
+	}
 }
 
-var errInvalidExtGlobFilterMissingSeparator = InvalidExtGlobFilterMissingSeparatorError{
+type CoreInvalidExtGlobFilterMissingSeparatorError struct {
+	li18ngo.LocalisableError
+}
+
+var errCoreInvalidExtGlobFilterMissingSeparator = CoreInvalidExtGlobFilterMissingSeparatorError{
 	LocalisableError: li18ngo.LocalisableError{
-		Data: InvalidExtGlobFilterMissingSeparatorErrorTemplData{},
+		Data: CoreInvalidExtGlobFilterMissingSeparatorErrorTemplData{},
 	},
 }
 
@@ -356,7 +409,7 @@ type PolyFilterIsInvalidTemplData struct {
 // Message
 func (td PolyFilterIsInvalidTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "poly-filter-is-invalid.error",
+		ID:          "poly-filter-is-invalid.static-error",
 		Description: "poly filter definition is invalid error",
 		Other:       "poly filter definition is invalid",
 	}
@@ -372,7 +425,7 @@ var ErrPolyFilterIsInvalid = PolyFilterIsInvalidError{
 	},
 }
 
-// ❌ UsageMissingRootPath
+// ❌ UsageMissingTreePath
 
 // UsageMissingRootPathTemplData
 type UsageMissingTreePathErrorTemplData struct {
@@ -382,17 +435,17 @@ type UsageMissingTreePathErrorTemplData struct {
 // Message
 func (td UsageMissingTreePathErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "usage-missing-tree-path.error",
+		ID:          "usage-missing-tree-path.static-error",
 		Description: "usage missing tree path",
 		Other:       "usage missing tree path",
 	}
 }
 
-type UsageMissingRootPathError struct {
+type UsageMissingTreePathError struct {
 	li18ngo.LocalisableError
 }
 
-var ErrUsageMissingRootPath = UsageMissingRootPathError{
+var ErrUsageMissingTreePath = UsageMissingTreePathError{
 	LocalisableError: li18ngo.LocalisableError{
 		Data: UsageMissingTreePathErrorTemplData{},
 	},
@@ -408,7 +461,7 @@ type UsageMissingRestorePathErrorTemplData struct {
 // Message
 func (td UsageMissingRestorePathErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "usage-missing-restore-path.error",
+		ID:          "usage-missing-restore-path.static-error",
 		Description: "usage missing restore path",
 		Other:       "usage missing restore path",
 	}
@@ -434,7 +487,7 @@ type UsageMissingSubscriptionErrorTemplData struct {
 // Message
 func (td UsageMissingSubscriptionErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "usage-missing-subscription.error",
+		ID:          "usage-missing-subscription.static-error",
 		Description: "usage missing subscription",
 		Other:       "usage missing subscription",
 	}
@@ -460,7 +513,7 @@ type UsageMissingHandlerErrorTemplData struct {
 // Message
 func (td UsageMissingHandlerErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "usage-missing-handler.error",
+		ID:          "usage-missing-handler.static-error",
 		Description: "usage missing handler",
 		Other:       "usage missing handler",
 	}
@@ -486,7 +539,7 @@ type IDGeneratorFuncCantBeNilErrorTemplData struct {
 // Message
 func (td IDGeneratorFuncCantBeNilErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "id-generator-func-cant-be-nil.error",
+		ID:          "id-generator-func-cant-be-nil.static-error",
 		Description: "id generator func is nil, should be defined",
 		Other:       "id generator func can't be nil",
 	}
@@ -512,7 +565,7 @@ type UnEqualJSONConversionErrorTemplData struct {
 // Message
 func (td UnEqualJSONConversionErrorTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "un-equal-conversion.error",
+		ID:          "un-equal-conversion.static-error",
 		Description: "JSON options conversion error",
 		Other:       "unequal JSON conversion",
 	}
@@ -530,116 +583,155 @@ var ErrUnEqualConversion = UnEqualConversionError{
 
 // ❌ InvalidPath
 
-// InvalidPathErrorTemplData invalid file system path; path must be relative
-// relative to the root already defined for this file system so should not
-// start or end with a /. Also, only a / should be used to denote a separator
-// which applies to all platforms.
-type InvalidPathErrorTemplData struct {
+type InvalidPathTemplData struct {
 	traverseTemplData
 	Path string
 }
 
-// IsInvalidExtGlobFilterMissingSeparatorError uses errors.Is to check
-// if the err's error tree contains the core error:
-// InvalidExtGlobFilterMissingSeparatorError
-func IsInvalidPathError(err error) bool {
-	return errors.Is(err, errInvalidPath)
-}
-
-func NewInvalidPathError(path string) error {
-	return errors.Wrap(
-		errInvalidPath,
-		li18ngo.Text(InvalidPathErrorTemplData{
-			Path: path,
-		}),
-	)
-}
-
-// Message
-func (td InvalidPathErrorTemplData) Message() *i18n.Message {
+func (td InvalidPathTemplData) Message() *i18n.Message {
 	return &i18n.Message{
-		ID:          "invalid-path.error",
-		Description: "Invalid file system path",
-		Other:       "invalid path {{.Path}}",
+		ID:          "invalid-path.dynamic-error",
+		Description: "invalid path dynamic error",
+		Other:       "path: {{.Path}}",
 	}
 }
 
 type InvalidPathError struct {
 	li18ngo.LocalisableError
+	Wrapped error
 }
 
-var errInvalidPath = InvalidPathError{
-	LocalisableError: li18ngo.LocalisableError{
-		Data: InvalidPathErrorTemplData{},
-	},
+func (e InvalidPathError) Error() string {
+	wrapped := e.Wrapped.Error()
+	path := li18ngo.Text(e.Data)
+	return fmt.Sprintf("%v, %v", wrapped, path)
 }
 
-// ❌ InvalidBinaryFsOp
-
-// InvalidBinaryFsOpErrorTemplData invalid file system operation
-// that involves 2 paths, typically a source and destination.
-// The error also indicates which operation is at fault.
-type InvalidBinaryFsOpErrorTemplData struct {
-	traverseTemplData
-	From string
-	To   string
-	Op   string
+func (e InvalidPathError) Unwrap() error {
+	return e.Wrapped
 }
 
-// IsInvalidExtGlobFilterMissingSeparatorError uses errors.Is to check
-// if the err's error tree contains the core error:
-// InvalidExtGlobFilterMissingSeparatorError
-func IsBinaryFsOpError(err error) bool {
-	return errors.Is(err, errCoreBinaryFsOp)
-}
-
-func NewInvalidBinaryFsOpError(op, from, to string) error {
-	return errors.Wrap(
-		errCoreBinaryFsOp,
-		li18ngo.Text(InvalidBinaryFsOpErrorTemplData{
-			From: from,
-			To:   to,
-			Op:   op,
-		}),
-	)
-}
-
-// Message
-func (td InvalidBinaryFsOpErrorTemplData) Message() *i18n.Message {
-	return &i18n.Message{
-		ID:          "invalid-binary-op.error",
-		Description: "Invalid file system operation",
-		Other:       "{{.Op}}, from: {{.From}}, to {{.To}}",
+func NewInvalidPathError(path string) error {
+	return &InvalidPathError{
+		LocalisableError: li18ngo.LocalisableError{
+			Data: InvalidPathTemplData{
+				Path: path,
+			},
+		},
+		Wrapped: errCoreInvalidPath,
 	}
 }
 
-// ❌ CoreBinaryFsOpError
+// ❌ CoreInvalidPathError
 
-type CoreBinaryFsOpErrorTemplData struct {
+type CoreInvalidPathErrorTemplData struct {
 	traverseTemplData
+}
+
+func IsInvalidPathError(err error) bool {
+	return errors.Is(err, errCoreInvalidPath)
+}
+
+func (td CoreInvalidPathErrorTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "invalid-path.core-error",
+		Description: "invalid path core error",
+		Other:       "invalid path",
+	}
+}
+
+type CoreInvalidPathError struct {
 	li18ngo.LocalisableError
 }
 
-func (td CoreBinaryFsOpErrorTemplData) Message() *i18n.Message {
-	return &i18n.Message{
-		ID:          "core-invalid-binary-op.error",
-		Description: "Core Invalid file system operation",
-		Other:       "invalid file system operation",
-	}
-}
-
-var errCoreBinaryFsOp = CoreBinaryFsOpErrorTemplData{
+var errCoreInvalidPath = CoreInvalidPathError{
 	LocalisableError: li18ngo.LocalisableError{
-		Data: CoreBinaryFsOpErrorTemplData{},
+		Data: CoreInvalidPathErrorTemplData{},
 	},
 }
 
-// ❌ RejectSameDirMoveError
+// BOOKMARK
 
-// RejectSameDirMoveErrorTemplData invalid file system operation
+// ❌ InvalidBinaryFsOp, can be used to adapt the non i18n nefilim.InvalidBinaryFsOp
+// error into an i18n one.
+
+type InvalidBinaryFsOpTemplData struct {
+	traverseTemplData
+	From string
+	To   string
+	Op   string
+}
+
+func (td InvalidBinaryFsOpTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "invalid-binary-op.dynamic-error",
+		Description: "invalid binary op dynamic error",
+		Other:       "tbd: {{.Field}}",
+	}
+}
+
+type InvalidBinaryFsOpError struct {
+	li18ngo.LocalisableError
+	Wrapped error
+}
+
+func (e InvalidBinaryFsOpError) Error() string {
+	return fmt.Sprintf("%v, %v", e.Wrapped.Error(), li18ngo.Text(e.Data))
+}
+
+func (e InvalidBinaryFsOpError) Unwrap() error {
+	return e.Wrapped
+}
+
+func NewInvalidBinaryFsOpError(op, from, to string) error {
+	return &InvalidBinaryFsOpError{
+		LocalisableError: li18ngo.LocalisableError{
+			Data: InvalidBinaryFsOpTemplData{
+				From: from,
+				To:   to,
+				Op:   op,
+			},
+		},
+		Wrapped: errCoreInvalidBinaryFsOp, // replace with nefilim version
+	}
+}
+
+// ❌ CoreInvalidBinaryFsOp
+
+type CoreInvalidBinaryFsOpErrorTemplData struct {
+	traverseTemplData
+}
+
+func IsInvalidBinaryFsOpError(err error) bool {
+	return errors.Is(err, errCoreInvalidBinaryFsOp)
+}
+
+func (td CoreInvalidBinaryFsOpErrorTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "invalid-binary-op.core-error",
+		Description: "invalid binary op core error",
+		Other:       "invalid binary op",
+	}
+}
+
+// will be replaced by nefilim.CoreInvalidBinaryFsOpError
+type CoreInvalidBinaryFsOpError struct {
+	li18ngo.LocalisableError
+}
+
+// this will be replaced by the nefilim.errCoreInvalidBinaryFsOp error
+var errCoreInvalidBinaryFsOp = CoreInvalidBinaryFsOpError{
+	LocalisableError: li18ngo.LocalisableError{
+		Data: CoreInvalidBinaryFsOpErrorTemplData{},
+	},
+}
+
+// ❌ RejectSameDirMoveError; replace with nefilim version
+
+// RejectSameDirMoveErrorTemplDataL invalid file system operation
 // that involves 2 paths, typically a source and destination.
 // The error also indicates which operation is at fault.
-type RejectSameDirMoveErrorTemplData struct {
+type RejectSameDirMoveErrorTemplDataL struct {
 	traverseTemplData
 	From string
 	To   string
@@ -649,14 +741,14 @@ type RejectSameDirMoveErrorTemplData struct {
 // IsInvalidExtGlobFilterMissingSeparatorError uses errors.Is to check
 // if the err's error tree contains the core error:
 // InvalidExtGlobFilterMissingSeparatorError
-func IsRejectSameDirMoveError(err error) bool {
-	return errors.Is(err, errCoreRejectSameDirMoveError)
+func IsRejectSameDirMoveErrorL(err error) bool {
+	return errors.Is(err, errCoreRejectSameDirMoveErrorL)
 }
 
-func NewRejectSameDirMoveError(op, from, to string) error {
+func NewRejectSameDirMoveErrorL(op, from, to string) error {
 	return errors.Wrap(
-		errCoreRejectSameDirMoveError,
-		li18ngo.Text(RejectSameDirMoveErrorTemplData{
+		errCoreRejectSameDirMoveErrorL,
+		li18ngo.Text(RejectSameDirMoveErrorTemplDataL{
 			From: from,
 			To:   to,
 			Op:   op,
@@ -665,7 +757,7 @@ func NewRejectSameDirMoveError(op, from, to string) error {
 }
 
 // Message
-func (td RejectSameDirMoveErrorTemplData) Message() *i18n.Message {
+func (td RejectSameDirMoveErrorTemplDataL) Message() *i18n.Message {
 	return &i18n.Message{
 		ID:          "reject-same-dir-move.error",
 		Description: "Reject same directory move operation as this is just a rename",
@@ -673,14 +765,14 @@ func (td RejectSameDirMoveErrorTemplData) Message() *i18n.Message {
 	}
 }
 
-// ❌ CoreRejectSameDirMoveError
+// ❌ CoreRejectSameDirMoveError; replace with nefilim version
 
-type CoreRejectSameDirMoveErrorTemplData struct {
+type CoreRejectSameDirMoveErrorTemplDataL struct {
 	traverseTemplData
 	li18ngo.LocalisableError
 }
 
-func (td CoreRejectSameDirMoveErrorTemplData) Message() *i18n.Message {
+func (td CoreRejectSameDirMoveErrorTemplDataL) Message() *i18n.Message {
 	return &i18n.Message{
 		ID:          "core-reject-same-dir-move.error",
 		Description: "Core reject same directory move operation as this is just a rename",
@@ -688,8 +780,9 @@ func (td CoreRejectSameDirMoveErrorTemplData) Message() *i18n.Message {
 	}
 }
 
-var errCoreRejectSameDirMoveError = CoreRejectSameDirMoveErrorTemplData{
+// replace with nefilim version
+var errCoreRejectSameDirMoveErrorL = CoreRejectSameDirMoveErrorTemplDataL{
 	LocalisableError: li18ngo.LocalisableError{
-		Data: CoreRejectSameDirMoveErrorTemplData{},
+		Data: CoreRejectSameDirMoveErrorTemplDataL{},
 	},
 }

--- a/locale/messages-errors_test.go
+++ b/locale/messages-errors_test.go
@@ -43,11 +43,11 @@ var _ = Describe("error messages", Ordered, func() {
 		}
 	})
 
-	Context("InvalidExtGlobFilterMissingSeparator error", func() {
+	Context("InvalidExtGlobFilterMissingSeparator error", func() { // PENDING
 		When("variant error created", func() {
 			It("should: render translated content", func() {
 				const (
-					expected = "pattern: foo: invalid extended glob filter definition; pattern is missing separator"
+					expected = "invalid extended glob filter definition; pattern is missing separator, pattern: foo"
 				)
 				text := locale.NewInvalidExtGlobFilterMissingSeparatorError(
 					"foo",
@@ -83,7 +83,7 @@ var _ = Describe("error messages", Ordered, func() {
 		When("variant error created", func() {
 			It("should: render translated content", func() {
 				const (
-					expected = "pattern: foo: invalid incase filter definition; pattern is missing separator"
+					expected = "invalid incase filter definition; pattern is missing separator, pattern: foo"
 				)
 				text := locale.NewInvalidIncaseFilterDefError(
 					"foo",

--- a/pref/options-sampling.go
+++ b/pref/options-sampling.go
@@ -48,7 +48,7 @@ type (
 		// condition is true. The predicate function should return false once condition
 		// has been met to complete the sample. Of course, the loop will only run while
 		// there are still remaining items to consider (ie there are no more entries
-		// to consider for the current traverse item).
+		// to consider for the current traverse node).
 		While WhileDirectoryPredicate
 	}
 

--- a/pref/using.go
+++ b/pref/using.go
@@ -41,7 +41,7 @@ type Using struct {
 // Validate checks that the properties on Using are all valid.
 func (u Using) Validate() error {
 	if u.Tree == "" {
-		return locale.ErrUsageMissingRootPath
+		return locale.ErrUsageMissingTreePath
 	}
 
 	return validate(&u)

--- a/synchronise.go
+++ b/synchronise.go
@@ -59,7 +59,7 @@ func (c *concurrent) Navigate(ctx context.Context) (core.TraverseResult, error) 
 		return c.kc.Result(ctx, c.err), c.err
 	}
 
-	c.decorator = func(node *core.Node) error {
+	c.decorator = func(servant Servant) error {
 		// c.decorator is the function we register with the navigator,
 		// so instead of invoking the client handler, the navigator
 		// will invoke the decorator, which will send a job to the pool
@@ -70,7 +70,7 @@ func (c *concurrent) Navigate(ctx context.Context) (core.TraverseResult, error) 
 		// either by a Tap or a bus event...
 		//
 		input := &TraverseInput{
-			Node:    node,
+			Servant: servant,
 			Handler: c.ext.using().Handler,
 		}
 
@@ -81,11 +81,11 @@ func (c *concurrent) Navigate(ctx context.Context) (core.TraverseResult, error) 
 
 	c.pool, c.err = pants.NewManifoldFuncPool(
 		ctx, func(input *TraverseInput) (*TraverseOutput, error) {
-			err := input.Handler(input.Node)
+			err := input.Handler(input.Servant)
 
 			return &TraverseOutput{
-				Node:  input.Node,
-				Error: err,
+				Servant: input.Servant,
+				Error:   err,
 			}, err
 		}, c.wg,
 		pants.WithSize(c.o.Concurrency.NoW),

--- a/traverse-api.go
+++ b/traverse-api.go
@@ -46,8 +46,9 @@ type NavigatorFactory interface {
 
 type (
 	// 🌀 core
-	Node   = core.Node
-	Client = core.Client
+	Client  = core.Client
+	Node    = core.Node
+	Servant = core.Servant
 
 	// 🌀 enums
 	Subscription   = enums.Subscription

--- a/traverse-suite_test.go
+++ b/traverse-suite_test.go
@@ -25,7 +25,7 @@ const (
 	folders     = 2
 )
 
-var noOpHandler = func(_ *tv.Node) error {
+var noOpHandler = func(_ tv.Servant) error {
 	return nil
 }
 


### PR DESCRIPTION
ref: rename item to node (#230)

ref: add servant interface (#230)

ref: rename file system fs variables (#230)

ref: add servant (#230)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `Servant` type to enhance node handling across various components.
  
- **Improvements**
  - Updated multiple method signatures to use `Servant` instead of `Node`, improving type safety and consistency.
  - Renamed fields and parameters for clarity, such as changing `traverseFS` to `fS`.
  
- **Bug Fixes**
  - Enhanced error handling with updated message formats for clarity and maintainability.

- **Documentation**
  - Updated comments and error messages to reflect new terminology and improve understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->