### PR TITLE
ref(life): rename cycle pkg to life (#260)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,10 +68,6 @@ tasks:
     cmds:
       - go test ./tapable
 
-  tc:
-    cmds:
-      - go test ./cycle
-
   lfs:
     cmds:
       - go test ./lfs
@@ -87,6 +83,10 @@ tasks:
   tl:
     cmds:
       - go test ./locale
+
+  tlc:
+    cmds:
+      - go test ./life
 
   tcore:
     cmds:

--- a/director-prime_test.go
+++ b/director-prime_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/snivilised/li18ngo"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/enums"
 	"github.com/snivilised/traverse/internal/opts"
 	"github.com/snivilised/traverse/internal/services"
+	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
@@ -113,7 +113,7 @@ var _ = Describe("Director(Prime)", Ordered, func() {
 							Subscription: tv.SubscribeFiles,
 							Handler:      noOpHandler,
 						},
-						tv.WithOnBegin(func(_ *cycle.BeginState) {}),
+						tv.WithOnBegin(func(_ *life.BeginState) {}),
 						tv.WithCPU(),
 					)).Navigate(ctx)
 

--- a/director-resume_test.go
+++ b/director-resume_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/snivilised/nefilim/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/enums"
 	"github.com/snivilised/traverse/internal/services"
+	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 )
@@ -27,7 +27,7 @@ var _ = Describe("Director(Resume)", Ordered, func() {
 
 	BeforeAll(func() {
 		restore = func(o *tv.Options) error {
-			o.Events.Begin.On(func(_ *cycle.BeginState) {})
+			o.Events.Begin.On(func(_ *life.BeginState) {})
 
 			return nil
 		}

--- a/internal/feat/hiber/hibernate-defs.go
+++ b/internal/feat/hiber/hibernate-defs.go
@@ -2,9 +2,9 @@ package hiber
 
 import (
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/enums"
 	"github.com/snivilised/traverse/internal/types"
+	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/pref"
 )
 
@@ -44,7 +44,7 @@ type (
 	}
 
 	profile interface {
-		init(controls *cycle.Controls) error
+		init(controls *life.Controls) error
 		next(servant core.Servant, node *core.Node,
 			inspection types.Inspection,
 		) (bool, error)
@@ -54,7 +54,7 @@ type (
 		ho       *core.HibernateOptions
 		fo       *pref.FilterOptions
 		triggers triggers
-		controls *cycle.Controls
+		controls *life.Controls
 	}
 )
 

--- a/internal/feat/hiber/hibernate-simple-profile.go
+++ b/internal/feat/hiber/hibernate-simple-profile.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/snivilised/li18ngo"
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/enums"
 	"github.com/snivilised/traverse/internal/filtering"
 	"github.com/snivilised/traverse/internal/types"
+	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/locale"
 )
 
@@ -18,7 +18,7 @@ type simple struct {
 	current state
 }
 
-func (p *simple) init(controls *cycle.Controls) error {
+func (p *simple) init(controls *life.Controls) error {
 	p.states = p.create()
 	p.controls = controls
 

--- a/internal/feat/resume/resume_test.go
+++ b/internal/feat/resume/resume_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/snivilised/li18ngo"
 	"github.com/snivilised/nefilim/luna"
 	tv "github.com/snivilised/traverse"
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/enums"
 	lab "github.com/snivilised/traverse/internal/laboratory"
 	"github.com/snivilised/traverse/internal/services"
+	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
@@ -91,7 +91,7 @@ var _ = Describe("Resume", Ordered, func() { // formerly resume-strategy_test
 					// end of synthetic assignments
 
 					if strategy == enums.ResumeStrategyFastward {
-						o.Events.Begin.On(func(_ *cycle.BeginState) {
+						o.Events.Begin.On(func(_ *life.BeginState) {
 							Fail("begin handler should not be invoked because begin notification muted")
 						})
 					}

--- a/internal/kernel/mediator.go
+++ b/internal/kernel/mediator.go
@@ -6,11 +6,11 @@ import (
 	"io/fs"
 
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/enums"
 	"github.com/snivilised/traverse/internal/level"
 	"github.com/snivilised/traverse/internal/measure"
 	"github.com/snivilised/traverse/internal/types"
+	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/pref"
 )
 
@@ -94,7 +94,7 @@ func (m *mediator) Arrange(active, order []enums.Role) {
 
 func (m *mediator) Ignite(ignition *types.Ignition) {
 	m.impl.Ignite(ignition)
-	m.resources.Binder.Controls.Begin.Dispatch()(&cycle.BeginState{
+	m.resources.Binder.Controls.Begin.Dispatch()(&life.BeginState{
 		Tree: m.tree,
 	})
 }

--- a/internal/laboratory/callbacks.go
+++ b/internal/laboratory/callbacks.go
@@ -8,19 +8,19 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive,stylecheck // ok
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/internal/third/lo"
+	"github.com/snivilised/traverse/life"
 )
 
-func Begin(em string) cycle.BeginHandler {
-	return func(state *cycle.BeginState) {
+func Begin(em string) life.BeginHandler {
+	return func(state *life.BeginState) {
 		GinkgoWriter.Printf(
 			"---> %v [traverse-navigator-test:BEGIN], tree: '%v'\n", em, state.Tree,
 		)
 	}
 }
 
-func End(em string) cycle.EndHandler {
+func End(em string) life.EndHandler {
 	return func(result core.TraverseResult) {
 		GinkgoWriter.Printf(
 			"---> %v [traverse-navigator-test:END], err: '%v'\n", em, result.Error(),

--- a/internal/opts/binder.go
+++ b/internal/opts/binder.go
@@ -1,18 +1,18 @@
 package opts
 
 import (
-	"github.com/snivilised/traverse/cycle"
+	"github.com/snivilised/traverse/life"
 )
 
 type (
 	// Binder contains items derived from Options
 	Binder struct {
-		Controls cycle.Controls
+		Controls life.Controls
 	}
 )
 
 func NewBinder() *Binder {
 	return &Binder{
-		Controls: cycle.NewControls(),
+		Controls: life.NewControls(),
 	}
 }

--- a/internal/types/definitions.go
+++ b/internal/types/definitions.go
@@ -6,10 +6,10 @@ import (
 
 	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/enums"
 	"github.com/snivilised/traverse/internal/measure"
 	"github.com/snivilised/traverse/internal/opts"
+	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/pref"
 )
 
@@ -51,7 +51,7 @@ type (
 	// PluginInit
 	PluginInit struct {
 		O        *pref.Options
-		Controls *cycle.Controls
+		Controls *life.Controls
 	}
 
 	// Mediator controls interactions between different entities of

--- a/life/event-ascend_test.go
+++ b/life/event-ascend_test.go
@@ -1,4 +1,4 @@
-package cycle_test
+package life_test
 
 import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok

--- a/life/event-begin_test.go
+++ b/life/event-begin_test.go
@@ -1,25 +1,27 @@
-package cycle_test
+package life_test
 
 import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
+
 	"github.com/snivilised/traverse/internal/opts"
+	"github.com/snivilised/traverse/life"
 )
 
 var _ = Describe("event", func() {
-	var description string
-
-	Context("sleep", func() {
+	Context("begin", func() {
 		Context("single", func() {
 			When("listener", func() {
 				It("🧪 should: invoke client's handler", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.Sleep.On(func(_ string) {
+					o.Events.Begin.On(func(_ *life.BeginState) {
 						invoked = true
 					})
-					binder.Controls.Sleep.Dispatch()(description)
+					binder.Controls.Begin.Dispatch()(&life.BeginState{
+						Tree: traversalRoot,
+					})
 
 					Expect(invoked).To(BeTrue())
 				})
@@ -30,16 +32,20 @@ var _ = Describe("event", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.Sleep.On(func(_ string) {
+					o.Events.Begin.On(func(_ *life.BeginState) {
 						invoked = true
 					})
-					binder.Controls.Sleep.Mute()
-					binder.Controls.Sleep.Dispatch()(description)
+					binder.Controls.Begin.Mute()
+					binder.Controls.Begin.Dispatch()(&life.BeginState{
+						Tree: traversalRoot,
+					})
 					Expect(invoked).To(BeFalse(), "notification not muted")
 
 					invoked = false
-					binder.Controls.Sleep.Unmute()
-					binder.Controls.Sleep.Dispatch()(description)
+					binder.Controls.Begin.Unmute()
+					binder.Controls.Begin.Dispatch()(&life.BeginState{
+						Tree: traversalRoot,
+					})
 					Expect(invoked).To(BeTrue(), "notification not muted")
 				})
 			})
@@ -51,21 +57,25 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.Sleep.On(func(_ string) {
+					o.Events.Begin.On(func(_ *life.BeginState) {
 						count++
 					})
-					o.Events.Sleep.On(func(_ string) {
+					o.Events.Begin.On(func(_ *life.BeginState) {
 						count++
 					})
-					binder.Controls.Sleep.Dispatch()(description)
+					binder.Controls.Begin.Dispatch()(&life.BeginState{
+						Tree: traversalRoot,
+					})
 					Expect(count).To(Equal(2), "not all listeners were invoked for first notification")
 
 					count = 0
-					o.Events.Sleep.On(func(_ string) {
+					o.Events.Begin.On(func(_ *life.BeginState) {
 						count++
 					})
 
-					binder.Controls.Sleep.Dispatch()(description)
+					binder.Controls.Begin.Dispatch()(&life.BeginState{
+						Tree: anotherRoot,
+					})
 					Expect(count).To(Equal(3), "not all listeners were invoked for second notification")
 				})
 			})
@@ -75,15 +85,17 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.Sleep.On(func(_ string) {
+					o.Events.Begin.On(func(_ *life.BeginState) {
 						count++
 					})
-					o.Events.Sleep.On(func(_ string) {
+					o.Events.Begin.On(func(_ *life.BeginState) {
 						count++
 					})
 
-					binder.Controls.Sleep.Mute()
-					binder.Controls.Sleep.Dispatch()(description)
+					binder.Controls.Begin.Mute()
+					binder.Controls.Begin.Dispatch()(&life.BeginState{
+						Tree: anotherRoot,
+					})
 
 					Expect(count).To(Equal(0), "notification not muted")
 				})
@@ -94,7 +106,9 @@ var _ = Describe("event", func() {
 			It("🧪 should: invoke no-op", func() {
 				_, binder, _ := opts.Get()
 
-				binder.Controls.Sleep.Dispatch()(description)
+				binder.Controls.Begin.Dispatch()(&life.BeginState{
+					Tree: traversalRoot,
+				})
 			})
 		})
 	})

--- a/life/event-descend_test.go
+++ b/life/event-descend_test.go
@@ -1,25 +1,27 @@
-package cycle_test
+package life_test
 
 import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
+
+	"github.com/snivilised/traverse/core"
 	"github.com/snivilised/traverse/internal/opts"
 )
 
 var _ = Describe("event", func() {
-	var description string
+	var node core.Node
 
-	Context("wake", func() {
+	Context("descend", func() {
 		Context("single", func() {
 			When("listener", func() {
 				It("🧪 should: invoke client's handler", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.Wake.On(func(_ string) {
+					o.Events.Descend.On(func(_ *core.Node) {
 						invoked = true
 					})
-					binder.Controls.Wake.Dispatch()(description)
+					binder.Controls.Descend.Dispatch()(&node)
 
 					Expect(invoked).To(BeTrue())
 				})
@@ -30,16 +32,16 @@ var _ = Describe("event", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.Wake.On(func(_ string) {
+					o.Events.Descend.On(func(_ *core.Node) {
 						invoked = true
 					})
-					binder.Controls.Wake.Mute()
-					binder.Controls.Wake.Dispatch()(description)
+					binder.Controls.Descend.Mute()
+					binder.Controls.Descend.Dispatch()(&node)
 					Expect(invoked).To(BeFalse(), "notification not muted")
 
 					invoked = false
-					binder.Controls.Wake.Unmute()
-					binder.Controls.Wake.Dispatch()(description)
+					binder.Controls.Descend.Unmute()
+					binder.Controls.Descend.Dispatch()(&node)
 					Expect(invoked).To(BeTrue(), "notification not muted")
 				})
 			})
@@ -51,21 +53,21 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.Wake.On(func(_ string) {
+					o.Events.Descend.On(func(_ *core.Node) {
 						count++
 					})
-					o.Events.Wake.On(func(_ string) {
+					o.Events.Descend.On(func(_ *core.Node) {
 						count++
 					})
-					binder.Controls.Wake.Dispatch()(description)
+					binder.Controls.Descend.Dispatch()(&node)
 					Expect(count).To(Equal(2), "not all listeners were invoked for first notification")
 
 					count = 0
-					o.Events.Wake.On(func(_ string) {
+					o.Events.Descend.On(func(_ *core.Node) {
 						count++
 					})
 
-					binder.Controls.Wake.Dispatch()(description)
+					binder.Controls.Descend.Dispatch()(&node)
 					Expect(count).To(Equal(3), "not all listeners were invoked for second notification")
 				})
 			})
@@ -75,15 +77,15 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.Wake.On(func(_ string) {
+					o.Events.Descend.On(func(_ *core.Node) {
 						count++
 					})
-					o.Events.Wake.On(func(_ string) {
+					o.Events.Descend.On(func(_ *core.Node) {
 						count++
 					})
 
-					binder.Controls.Wake.Mute()
-					binder.Controls.Wake.Dispatch()(description)
+					binder.Controls.Descend.Mute()
+					binder.Controls.Descend.Dispatch()(&node)
 
 					Expect(count).To(Equal(0), "notification not muted")
 				})
@@ -94,7 +96,7 @@ var _ = Describe("event", func() {
 			It("🧪 should: invoke no-op", func() {
 				_, binder, _ := opts.Get()
 
-				binder.Controls.Wake.Dispatch()(description)
+				binder.Controls.Descend.Dispatch()(&node)
 			})
 		})
 	})

--- a/life/event-end_test.go
+++ b/life/event-end_test.go
@@ -1,4 +1,4 @@
-package cycle_test
+package life_test
 
 import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
@@ -6,22 +6,23 @@ import (
 
 	"github.com/snivilised/traverse/core"
 	"github.com/snivilised/traverse/internal/opts"
+	"github.com/snivilised/traverse/internal/types"
 )
 
 var _ = Describe("event", func() {
-	var node core.Node
+	var result types.KernelResult
 
-	Context("descend", func() {
+	Context("end", func() {
 		Context("single", func() {
 			When("listener", func() {
 				It("🧪 should: invoke client's handler", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.Descend.On(func(_ *core.Node) {
+					o.Events.End.On(func(_ core.TraverseResult) {
 						invoked = true
 					})
-					binder.Controls.Descend.Dispatch()(&node)
+					binder.Controls.End.Dispatch()(&result)
 
 					Expect(invoked).To(BeTrue())
 				})
@@ -32,16 +33,16 @@ var _ = Describe("event", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.Descend.On(func(_ *core.Node) {
+					o.Events.End.On(func(_ core.TraverseResult) {
 						invoked = true
 					})
-					binder.Controls.Descend.Mute()
-					binder.Controls.Descend.Dispatch()(&node)
+					binder.Controls.End.Mute()
+					binder.Controls.End.Dispatch()(&result)
 					Expect(invoked).To(BeFalse(), "notification not muted")
 
 					invoked = false
-					binder.Controls.Descend.Unmute()
-					binder.Controls.Descend.Dispatch()(&node)
+					binder.Controls.End.Unmute()
+					binder.Controls.End.Dispatch()(&result)
 					Expect(invoked).To(BeTrue(), "notification not muted")
 				})
 			})
@@ -53,21 +54,21 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.Descend.On(func(_ *core.Node) {
+					o.Events.End.On(func(_ core.TraverseResult) {
 						count++
 					})
-					o.Events.Descend.On(func(_ *core.Node) {
+					o.Events.End.On(func(_ core.TraverseResult) {
 						count++
 					})
-					binder.Controls.Descend.Dispatch()(&node)
+					binder.Controls.End.Dispatch()(&result)
 					Expect(count).To(Equal(2), "not all listeners were invoked for first notification")
 
 					count = 0
-					o.Events.Descend.On(func(_ *core.Node) {
+					o.Events.End.On(func(_ core.TraverseResult) {
 						count++
 					})
 
-					binder.Controls.Descend.Dispatch()(&node)
+					binder.Controls.End.Dispatch()(&result)
 					Expect(count).To(Equal(3), "not all listeners were invoked for second notification")
 				})
 			})
@@ -77,15 +78,15 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.Descend.On(func(_ *core.Node) {
+					o.Events.End.On(func(_ core.TraverseResult) {
 						count++
 					})
-					o.Events.Descend.On(func(_ *core.Node) {
+					o.Events.End.On(func(_ core.TraverseResult) {
 						count++
 					})
 
-					binder.Controls.Descend.Mute()
-					binder.Controls.Descend.Dispatch()(&node)
+					binder.Controls.End.Mute()
+					binder.Controls.End.Dispatch()(&result)
 
 					Expect(count).To(Equal(0), "notification not muted")
 				})
@@ -96,7 +97,7 @@ var _ = Describe("event", func() {
 			It("🧪 should: invoke no-op", func() {
 				_, binder, _ := opts.Get()
 
-				binder.Controls.Descend.Dispatch()(&node)
+				binder.Controls.End.Dispatch()(&result)
 			})
 		})
 	})

--- a/life/event-sleep_test.go
+++ b/life/event-sleep_test.go
@@ -1,28 +1,25 @@
-package cycle_test
+package life_test
 
 import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
-
-	"github.com/snivilised/traverse/core"
 	"github.com/snivilised/traverse/internal/opts"
-	"github.com/snivilised/traverse/internal/types"
 )
 
 var _ = Describe("event", func() {
-	var result types.KernelResult
+	var description string
 
-	Context("end", func() {
+	Context("sleep", func() {
 		Context("single", func() {
 			When("listener", func() {
 				It("🧪 should: invoke client's handler", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.End.On(func(_ core.TraverseResult) {
+					o.Events.Sleep.On(func(_ string) {
 						invoked = true
 					})
-					binder.Controls.End.Dispatch()(&result)
+					binder.Controls.Sleep.Dispatch()(description)
 
 					Expect(invoked).To(BeTrue())
 				})
@@ -33,16 +30,16 @@ var _ = Describe("event", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.End.On(func(_ core.TraverseResult) {
+					o.Events.Sleep.On(func(_ string) {
 						invoked = true
 					})
-					binder.Controls.End.Mute()
-					binder.Controls.End.Dispatch()(&result)
+					binder.Controls.Sleep.Mute()
+					binder.Controls.Sleep.Dispatch()(description)
 					Expect(invoked).To(BeFalse(), "notification not muted")
 
 					invoked = false
-					binder.Controls.End.Unmute()
-					binder.Controls.End.Dispatch()(&result)
+					binder.Controls.Sleep.Unmute()
+					binder.Controls.Sleep.Dispatch()(description)
 					Expect(invoked).To(BeTrue(), "notification not muted")
 				})
 			})
@@ -54,21 +51,21 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.End.On(func(_ core.TraverseResult) {
+					o.Events.Sleep.On(func(_ string) {
 						count++
 					})
-					o.Events.End.On(func(_ core.TraverseResult) {
+					o.Events.Sleep.On(func(_ string) {
 						count++
 					})
-					binder.Controls.End.Dispatch()(&result)
+					binder.Controls.Sleep.Dispatch()(description)
 					Expect(count).To(Equal(2), "not all listeners were invoked for first notification")
 
 					count = 0
-					o.Events.End.On(func(_ core.TraverseResult) {
+					o.Events.Sleep.On(func(_ string) {
 						count++
 					})
 
-					binder.Controls.End.Dispatch()(&result)
+					binder.Controls.Sleep.Dispatch()(description)
 					Expect(count).To(Equal(3), "not all listeners were invoked for second notification")
 				})
 			})
@@ -78,15 +75,15 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.End.On(func(_ core.TraverseResult) {
+					o.Events.Sleep.On(func(_ string) {
 						count++
 					})
-					o.Events.End.On(func(_ core.TraverseResult) {
+					o.Events.Sleep.On(func(_ string) {
 						count++
 					})
 
-					binder.Controls.End.Mute()
-					binder.Controls.End.Dispatch()(&result)
+					binder.Controls.Sleep.Mute()
+					binder.Controls.Sleep.Dispatch()(description)
 
 					Expect(count).To(Equal(0), "notification not muted")
 				})
@@ -97,7 +94,7 @@ var _ = Describe("event", func() {
 			It("🧪 should: invoke no-op", func() {
 				_, binder, _ := opts.Get()
 
-				binder.Controls.End.Dispatch()(&result)
+				binder.Controls.Sleep.Dispatch()(description)
 			})
 		})
 	})

--- a/life/event-wake_test.go
+++ b/life/event-wake_test.go
@@ -1,27 +1,25 @@
-package cycle_test
+package life_test
 
 import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
-
-	"github.com/snivilised/traverse/cycle"
 	"github.com/snivilised/traverse/internal/opts"
 )
 
 var _ = Describe("event", func() {
-	Context("begin", func() {
+	var description string
+
+	Context("wake", func() {
 		Context("single", func() {
 			When("listener", func() {
 				It("🧪 should: invoke client's handler", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.Begin.On(func(_ *cycle.BeginState) {
+					o.Events.Wake.On(func(_ string) {
 						invoked = true
 					})
-					binder.Controls.Begin.Dispatch()(&cycle.BeginState{
-						Tree: traversalRoot,
-					})
+					binder.Controls.Wake.Dispatch()(description)
 
 					Expect(invoked).To(BeTrue())
 				})
@@ -32,20 +30,16 @@ var _ = Describe("event", func() {
 					invoked := false
 					o, binder, _ := opts.Get()
 
-					o.Events.Begin.On(func(_ *cycle.BeginState) {
+					o.Events.Wake.On(func(_ string) {
 						invoked = true
 					})
-					binder.Controls.Begin.Mute()
-					binder.Controls.Begin.Dispatch()(&cycle.BeginState{
-						Tree: traversalRoot,
-					})
+					binder.Controls.Wake.Mute()
+					binder.Controls.Wake.Dispatch()(description)
 					Expect(invoked).To(BeFalse(), "notification not muted")
 
 					invoked = false
-					binder.Controls.Begin.Unmute()
-					binder.Controls.Begin.Dispatch()(&cycle.BeginState{
-						Tree: traversalRoot,
-					})
+					binder.Controls.Wake.Unmute()
+					binder.Controls.Wake.Dispatch()(description)
 					Expect(invoked).To(BeTrue(), "notification not muted")
 				})
 			})
@@ -57,25 +51,21 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.Begin.On(func(_ *cycle.BeginState) {
+					o.Events.Wake.On(func(_ string) {
 						count++
 					})
-					o.Events.Begin.On(func(_ *cycle.BeginState) {
+					o.Events.Wake.On(func(_ string) {
 						count++
 					})
-					binder.Controls.Begin.Dispatch()(&cycle.BeginState{
-						Tree: traversalRoot,
-					})
+					binder.Controls.Wake.Dispatch()(description)
 					Expect(count).To(Equal(2), "not all listeners were invoked for first notification")
 
 					count = 0
-					o.Events.Begin.On(func(_ *cycle.BeginState) {
+					o.Events.Wake.On(func(_ string) {
 						count++
 					})
 
-					binder.Controls.Begin.Dispatch()(&cycle.BeginState{
-						Tree: anotherRoot,
-					})
+					binder.Controls.Wake.Dispatch()(description)
 					Expect(count).To(Equal(3), "not all listeners were invoked for second notification")
 				})
 			})
@@ -85,17 +75,15 @@ var _ = Describe("event", func() {
 					count := 0
 					o, binder, _ := opts.Get()
 
-					o.Events.Begin.On(func(_ *cycle.BeginState) {
+					o.Events.Wake.On(func(_ string) {
 						count++
 					})
-					o.Events.Begin.On(func(_ *cycle.BeginState) {
+					o.Events.Wake.On(func(_ string) {
 						count++
 					})
 
-					binder.Controls.Begin.Mute()
-					binder.Controls.Begin.Dispatch()(&cycle.BeginState{
-						Tree: anotherRoot,
-					})
+					binder.Controls.Wake.Mute()
+					binder.Controls.Wake.Dispatch()(description)
 
 					Expect(count).To(Equal(0), "notification not muted")
 				})
@@ -106,9 +94,7 @@ var _ = Describe("event", func() {
 			It("🧪 should: invoke no-op", func() {
 				_, binder, _ := opts.Get()
 
-				binder.Controls.Begin.Dispatch()(&cycle.BeginState{
-					Tree: traversalRoot,
-				})
+				binder.Controls.Wake.Dispatch()(description)
 			})
 		})
 	})

--- a/life/events.go
+++ b/life/events.go
@@ -1,4 +1,4 @@
-package cycle
+package life
 
 import (
 	"github.com/snivilised/traverse/core"

--- a/life/events_test.go
+++ b/life/events_test.go
@@ -1,4 +1,4 @@
-package cycle_test
+package life_test
 
 import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
@@ -6,7 +6,7 @@ import (
 
 	"github.com/snivilised/li18ngo"
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
+	"github.com/snivilised/traverse/life"
 )
 
 var _ = Describe("controls", Ordered, func() {
@@ -19,8 +19,8 @@ var _ = Describe("controls", Ordered, func() {
 			const path = "/traversal-tree"
 
 			var (
-				controls cycle.Controls
-				events   cycle.Events
+				controls life.Controls
+				events   life.Events
 				begun    bool
 				ended    bool
 			)
@@ -31,7 +31,7 @@ var _ = Describe("controls", Ordered, func() {
 
 			// client:
 			//
-			events.Begin.On(func(state *cycle.BeginState) {
+			events.Begin.On(func(state *life.BeginState) {
 				begun = true
 				Expect(state.Tree).To(Equal(path))
 			})
@@ -42,7 +42,7 @@ var _ = Describe("controls", Ordered, func() {
 
 			// component side:
 			//
-			controls.Begin.Dispatch()(&cycle.BeginState{
+			controls.Begin.Dispatch()(&life.BeginState{
 				Tree: path,
 			})
 			controls.End.Dispatch()(nil)

--- a/life/life-defs.go
+++ b/life/life-defs.go
@@ -1,10 +1,10 @@
-package cycle
+package life
 
 import (
 	"github.com/snivilised/traverse/core"
 )
 
-// 📦 pkg: cycle - represents life cycle events; can't use prefs
+// 📦 pkg: life - represents life cycle events; can't use prefs
 
 // beforeX
 // afterX

--- a/life/life-suite_test.go
+++ b/life/life-suite_test.go
@@ -1,4 +1,4 @@
-package cycle_test
+package life_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 )
 
-func TestCycle(t *testing.T) {
+func TestLife(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Cycle Suite")
+	RunSpecs(t, "Life Suite")
 }

--- a/life/support_test.go
+++ b/life/support_test.go
@@ -1,4 +1,4 @@
-package cycle_test
+package life_test
 
 const (
 	traversalRoot = "/traversal-tree"

--- a/pref/options-life.go
+++ b/pref/options-life.go
@@ -1,13 +1,13 @@
 package pref
 
 import (
-	"github.com/snivilised/traverse/cycle"
+	"github.com/snivilised/traverse/life"
 )
 
 // WithOnAscend sets ascend handler, invoked when navigator
 // traverses up a directory, ie after all children have been
 // visited.
-func WithOnAscend(handler cycle.NodeHandler) Option {
+func WithOnAscend(handler life.NodeHandler) Option {
 	return func(o *Options) error {
 		o.Events.Ascend.On(handler)
 
@@ -17,7 +17,7 @@ func WithOnAscend(handler cycle.NodeHandler) Option {
 
 // WithOnBegin sets the begin handler, invoked before the start
 // of a traversal session.
-func WithOnBegin(handler cycle.BeginHandler) Option {
+func WithOnBegin(handler life.BeginHandler) Option {
 	return func(o *Options) error {
 		o.Events.Begin.On(handler)
 
@@ -27,7 +27,7 @@ func WithOnBegin(handler cycle.BeginHandler) Option {
 
 // WithOnDescend sets the descend handler, invoked when navigator
 // traverses down into a child directory.
-func WithOnDescend(handler cycle.NodeHandler) Option {
+func WithOnDescend(handler life.NodeHandler) Option {
 	return func(o *Options) error {
 		o.Events.Descend.On(handler)
 
@@ -37,7 +37,7 @@ func WithOnDescend(handler cycle.NodeHandler) Option {
 
 // WithOnEnd sets the end handler, invoked at the end of a traversal
 // session.
-func WithOnEnd(handler cycle.EndHandler) Option {
+func WithOnEnd(handler life.EndHandler) Option {
 	return func(o *Options) error {
 		o.Events.End.On(handler)
 
@@ -48,7 +48,7 @@ func WithOnEnd(handler cycle.EndHandler) Option {
 // WithOnWake sets the wake handler, when hibernation is active
 // and the wake condition has occurred, ie when a file system
 // node is encountered that matches the hibernation's wake filter.
-func WithOnWake(handler cycle.HibernateHandler) Option {
+func WithOnWake(handler life.HibernateHandler) Option {
 	return func(o *Options) error {
 		o.Events.Wake.On(handler)
 
@@ -59,7 +59,7 @@ func WithOnWake(handler cycle.HibernateHandler) Option {
 // WithOnSleep sets the sleep handler, when hibernation is active
 // and the sleep condition has occurred, ie when a file system
 // node is encountered that matches the hibernation's sleep filter.
-func WithOnSleep(handler cycle.HibernateHandler) Option {
+func WithOnSleep(handler life.HibernateHandler) Option {
 	return func(o *Options) error {
 		o.Events.Sleep.On(handler)
 

--- a/pref/options.go
+++ b/pref/options.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/cycle"
+	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/tapable"
 )
 
@@ -38,7 +38,7 @@ type (
 
 		// Events provides the ability to tap into life cycle events
 		//
-		Events cycle.Events
+		Events life.Events
 
 		// Hooks contains client hook-able functions
 		//

--- a/traverse-api.go
+++ b/traverse-api.go
@@ -273,7 +273,7 @@ var (
 
 // This high level list assumes everything can use core and enums; dependencies
 // can only point downwards. NB: These restrictions do not apply to the unit tests;
-// eg, "cycle_test" defines tests that are dependent on "pref", but "cycle" is prohibited
+// eg, "life_test" defines tests that are dependent on "pref", but "life" is prohibited
 // from using "pref".
 // ============================================================================
 // 🔆 user interface layer
@@ -294,13 +294,13 @@ var (
 // ---
 //
 // 🔆 support layer
-// pref: ["cycle", "services", "persist(to-be-confirmed)"] actually, persist should be part of pref
+// pref: ["life", "services", "persist(to-be-confirmed)"] actually, persist should be part of pref
 // persist: []
 // services: []
 // ---
 //
 // 🔆 intermediary layer
-// cycle: [], !("pref")
+// life: [], !("pref")
 // ---
 //
 // 🔆 platform layer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new task `tlc` for executing tests related to `life`.
	- Added a new `Events` struct to encapsulate lifecycle events.

- **Bug Fixes**
	- Updated event handling to utilize new state management from the `life` package.

- **Documentation**
	- Updated comments and documentation to reflect the transition from `cycle` to `life`.

- **Refactor**
	- Renamed package from `cycle` to `life` across multiple files, enhancing clarity and modularity.
	- Altered function signatures to replace `cycle` references with `life` in various event handling functions.

- **Tests**
	- Updated test files to reflect the new package name and event handling logic while maintaining existing test structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->