### PR TITLE
ref(resume): add kernel controller to plugin init (#272)

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -91,8 +91,9 @@ func (bs *Builders) buildAll() (*buildArtefacts, error) {
 	artefacts.Mediator.Arrange(active, order)
 
 	pi := &types.PluginInit{
-		O:        harvest.Options(),
-		Controls: &harvest.Binder().Controls,
+		O:          harvest.Options(),
+		Kontroller: artefacts.Kontroller,
+		Controls:   &harvest.Binder().Controls,
 	}
 
 	for _, p := range plugins {

--- a/director.go
+++ b/director.go
@@ -165,7 +165,7 @@ func Resume(was *Was, settings ...pref.Option) *Builders {
 				w: was,
 			}
 		}),
-		// we need state; record the hibernation wake point, so
+		// TODO: we need state; record the hibernation wake point, so
 		// using a func here is probably not optimal.
 		//
 		harvest: optionBuilder(func(ext extent) (harvest types.OptionHarvest, err error) {

--- a/internal/feat/resume/controller.go
+++ b/internal/feat/resume/controller.go
@@ -42,36 +42,6 @@ func (c *Controller) Conclude(result core.TraverseResult) {
 	c.kc.Conclude(result)
 }
 
-// this is not named correctly
-func NewController(was *pref.Was, harvest types.OptionHarvest,
-	artefacts *kernel.Artefacts,
-) *kernel.Artefacts {
-	// The Controller on the incoming artefacts is the core navigator. It is
-	// decorated here for resume. The strategy only needs access to the core navigator.
-	// The resume navigator delegates to the strategy.
-	//
-	var (
-		strategy resumeStrategy
-		err      error
-	)
-	if strategy, err = newStrategy(was, harvest, artefacts.Kontroller); err != nil {
-		return artefacts
-	}
-
-	return &kernel.Artefacts{
-		Kontroller: &Controller{
-			kc:         artefacts.Kontroller,
-			was:        was,
-			load:       harvest.Loaded(),
-			strategy:   strategy,
-			facilities: artefacts.Facilities,
-		},
-		Mediator:  artefacts.Mediator,
-		Resources: artefacts.Resources,
-		IfResult:  strategy.ifResult,
-	}
-}
-
 func newStrategy(was *pref.Was,
 	harvest types.OptionHarvest,
 	kc types.KernelController,

--- a/internal/feat/resume/resume-plugin.go
+++ b/internal/feat/resume/resume-plugin.go
@@ -14,9 +14,12 @@ type Plugin struct {
 	kernel.BasePlugin
 	IfResult core.ResultCompletion
 	Active   *core.ActiveState
+	guardian types.Guardian
 }
 
-func (p *Plugin) Init(_ *types.PluginInit) error {
+func (p *Plugin) Init(pi *types.PluginInit) error {
+	p.guardian = pi.Kontroller.Mediator()
+
 	return nil
 }
 
@@ -42,4 +45,35 @@ func Load(restoration *types.RestoreState,
 	_ = err // TODO: don't forget to handle this
 
 	return opts.Bind(result.O, result.Active, settings...)
+}
+
+// this is not named correctly
+func NewController(was *pref.Was, harvest types.OptionHarvest,
+	artefacts *kernel.Artefacts,
+) *kernel.Artefacts {
+	// The Controller on the incoming artefacts is the core navigator. It is
+	// decorated here for resume. The strategy only needs access to the core navigator.
+	// The resume navigator delegates to the strategy.
+	//
+	var (
+		strategy resumeStrategy
+		err      error
+	)
+
+	if strategy, err = newStrategy(was, harvest, artefacts.Kontroller); err != nil {
+		return artefacts
+	}
+
+	return &kernel.Artefacts{
+		Kontroller: &Controller{
+			kc:         artefacts.Kontroller,
+			was:        was,
+			load:       harvest.Loaded(),
+			strategy:   strategy,
+			facilities: artefacts.Facilities,
+		},
+		Mediator:  artefacts.Mediator,
+		Resources: artefacts.Resources,
+		IfResult:  strategy.ifResult,
+	}
 }

--- a/internal/types/definitions.go
+++ b/internal/types/definitions.go
@@ -50,8 +50,9 @@ type (
 
 	// PluginInit
 	PluginInit struct {
-		O        *pref.Options
-		Controls *life.Controls
+		O          *pref.Options
+		Kontroller KernelController
+		Controls   *life.Controls
 	}
 
 	// Mediator controls interactions between different entities of


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Kontroller` field in the `PluginInit` structure, enhancing plugin initialization.
	- Added a new `guardian` field in the `Plugin` struct for improved functionality.
	- Implemented a new `NewController` function for creating `Controller` instances.

- **Bug Fixes**
	- Updated error handling in the `Init` method to properly utilize the new `Kontroller` field.

- **Documentation**
	- Added comments to clarify future tasks and improve code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->