### PR TITLE
fix(venus): add read dir hook to filter out entries name=. (#282)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
       "cwd": "${workspaceFolder}",
     },
     {
+      "name": "Debug(root) Venus CLI",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/test/cmd/venus/main.go",
+      "args": ["-path", ".", "-pattern", "*|flac"],
+      "cwd": "${workspaceFolder}",
+    },
+    {
       "name": "Launch Package",
       "type": "go",
       "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,6 +33,23 @@
       "problemMatcher": [
         "$go"
       ]
+    },
+    {
+      "label": "Root Venus CLI",
+      "type": "shell",
+      "command": "go",
+      "args": [
+        "run",
+        "${workspaceFolder}/test/cmd/venus/main.go",
+        "-path",
+        ".",
+        "-pattern",
+        "*|flac"
+      ],
+      "group": "build",
+      "problemMatcher": [
+        "$go"
+      ]
     }
   ]
 }

--- a/internal/kernel/navigator-vanilla_test.go
+++ b/internal/kernel/navigator-vanilla_test.go
@@ -96,6 +96,7 @@ var _ = Describe("NavigatorUniversal", Ordered, func() {
 					_, found := recording[p]
 					return found
 				},
+				ByPassMetrics: entry.ByPassMetrics,
 			})
 		},
 		func(entry *lab.NaviTE) string {
@@ -136,6 +137,14 @@ var _ = Describe("NavigatorUniversal", Ordered, func() {
 				Files:       14,
 				Directories: 8,
 			},
+		}),
+
+		Entry(nil, Label(lab.Static.RetroWave), &lab.NaviTE{
+			Given:         "universal: Path is Root",
+			Relative:      ".",
+			Subscription:  enums.SubscribeUniversal,
+			Callback:      lab.UniversalCallback("ROOT-PATH"),
+			ByPassMetrics: true,
 		}),
 
 		// === directories ===================================================

--- a/internal/laboratory/helper-defs.go
+++ b/internal/laboratory/helper-defs.go
@@ -18,6 +18,7 @@ type (
 		Callback      core.Client
 		Mandatory     []string
 		Prohibited    []string
+		ByPassMetrics bool
 		ExpectedNoOf  Quantities
 		ExpectedErr   error
 	}

--- a/test/cmd/venus/main.go
+++ b/test/cmd/venus/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -143,6 +144,7 @@ func navigate(n *navigation) {
 				},
 			})
 		}),
+		tv.WithHookReadDirectory(readEntriesHook),
 	)).Navigate(ctx)
 
 	if err != nil {
@@ -167,4 +169,20 @@ func subscribe(sub string) enums.Subscription {
 	}
 
 	return subscription
+}
+
+func readEntriesHook(sys fs.ReadDirFS,
+	dirname string,
+) ([]fs.DirEntry, error) {
+	contents, err := fs.ReadDir(sys, dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := lo.Filter(contents, func(item fs.DirEntry, _ int) bool {
+		name := item.Name()
+		return name != ".DS_Store" && name != "."
+	})
+
+	return filtered, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new debugging configuration for the Venus CLI to operate on the current directory.
	- Added a new task to run the Venus CLI with the current directory as the path.

- **Bug Fixes**
	- Enhanced navigation logic to handle scenarios where the path is the root directory.

- **Documentation**
	- Updated test coverage to include a scenario for root directory navigation.

- **Chores**
	- Implemented a filtering mechanism to exclude unwanted directory entries during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->