### PR TITLE
feat(resume): initial spawn resume implementation (#273)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -99,6 +99,7 @@
     "rsys",
     "samber",
     "samp",
+    "sess",
     "shogo",
     "sidewalk",
     "snivilisation",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,6 +60,10 @@ tasks:
     cmds:
       - go clean -testcache
 
+  lfs:
+    cmds:
+      - go test ./lfs
+
   t:
     cmds:
       - go test ./...
@@ -68,9 +72,9 @@ tasks:
     cmds:
       - go test ./tapable
 
-  lfs:
+  ten:
     cmds:
-      - go test ./lfs
+     - go test ./internal/types
 
   tk:
     cmds:

--- a/internal/feat/resume/resume-defs.go
+++ b/internal/feat/resume/resume-defs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/snivilised/traverse/core"
+	"github.com/snivilised/traverse/internal/kernel"
 	"github.com/snivilised/traverse/internal/opts"
 	"github.com/snivilised/traverse/internal/types"
 	"github.com/snivilised/traverse/pref"
@@ -14,20 +15,35 @@ import (
 // these may be internal modules, eg internal/serial/JSON).
 
 const (
-	badge = "badge: resume"
+	badge             = "badge: resume"
+	followingSiblings = true
 )
 
-type Strategy interface {
-	types.Link
-	init(load *opts.LoadInfo) error
-	resume(context.Context, *pref.Was) (*types.KernelResult, error)
-	ifResult() bool
-	finish() error
-}
+type (
+	Strategy interface {
+		init(load *opts.LoadInfo) error
+		resume(context.Context, *pref.Was) (*types.KernelResult, error)
+		ifResult() bool
+		finish() error
+	}
 
-type baseStrategy struct {
-	active   *core.ActiveState
-	was      *pref.Was
-	sealer   types.GuardianSealer
-	mediator types.Mediator
-}
+	baseStrategy struct {
+		o        *pref.Options
+		active   *core.ActiveState
+		was      *pref.Was
+		sealer   types.GuardianSealer
+		kc       types.KernelController
+		mediator types.Mediator
+	}
+
+	concludeInfo struct {
+		active    *core.ActiveState
+		tree      string
+		current   string
+		inclusive bool
+	}
+
+	shard struct {
+		siblings *kernel.Contents
+	}
+)

--- a/internal/feat/resume/strategy-fastward.go
+++ b/internal/feat/resume/strategy-fastward.go
@@ -71,6 +71,7 @@ func (g *fastwardGuardianSealer) IsSealed(types.Link) bool {
 
 type fastwardStrategy struct {
 	baseStrategy
+	types.Link
 	role   enums.Role
 	filter core.TraverseFilter
 }
@@ -119,6 +120,8 @@ func (s *fastwardStrategy) Next(servant core.Servant,
 	match = s.filter.IsMatch(servant.Node())
 
 	if match {
+		// TODO: unmute notifications
+		//
 		err = s.mediator.Unwind(s.role)
 	}
 

--- a/internal/feat/resume/strategy-spawn.go
+++ b/internal/feat/resume/strategy-spawn.go
@@ -2,9 +2,12 @@ package resume
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
 
 	"github.com/snivilised/traverse/core"
-	"github.com/snivilised/traverse/enums"
 	"github.com/snivilised/traverse/internal/opts"
 	"github.com/snivilised/traverse/internal/types"
 	"github.com/snivilised/traverse/pref"
@@ -18,25 +21,18 @@ func (s *spawnStrategy) init(*opts.LoadInfo) error {
 	return nil
 }
 
-// Next invokes this decorator which returns true if
-// next link in the chain can be run or false to stop
-// execution of subsequent links.
-func (s *spawnStrategy) Next(_ core.Servant,
-	_ types.Inspection,
-) (bool, error) {
-	return true, nil
-}
-
-// Role indicates the identity of the link
-func (s *spawnStrategy) Role() enums.Role {
-	// what role?
-	return enums.RoleFastward
-}
-
-func (s *spawnStrategy) resume(_ context.Context,
+func (s *spawnStrategy) resume(ctx context.Context,
 	_ *pref.Was,
 ) (*types.KernelResult, error) {
-	return nil, nil
+	// what is the equivalent of this?:
+	// s.nc.frame.root.Set(info.ps.Active.Root)
+	//
+	return s.conclude(ctx, &concludeInfo{
+		active:    s.active,
+		tree:      s.active.Tree,
+		current:   s.active.CurrentPath,
+		inclusive: true,
+	})
 }
 
 func (s *spawnStrategy) finish() error {
@@ -45,4 +41,82 @@ func (s *spawnStrategy) finish() error {
 
 func (s *spawnStrategy) ifResult() bool {
 	return true // TODO: tbd...
+}
+
+func (s *spawnStrategy) conclude(ctx context.Context,
+	conclusion *concludeInfo,
+) (*types.KernelResult, error) {
+	if conclusion.current == conclusion.active.Tree {
+		// reach the top, so we're done
+		//
+		err := errors.New("fake spawn result")
+		return s.kc.Result(ctx, err), err
+	}
+
+	// TODO: impl pending:
+
+	return &types.KernelResult{
+		// spawn not complete yet
+	}, nil
+}
+
+type seedParams struct {
+	parent     string
+	entries    []fs.DirEntry
+	conclusion *concludeInfo
+}
+
+func (s *spawnStrategy) seed(ctx context.Context,
+	parent string,
+	entries []fs.DirEntry,
+	conclusion *concludeInfo,
+) (*types.KernelResult, error) {
+	s.mediator.Connect(conclusion.tree, conclusion.current)
+
+	compoundResult := &types.KernelResult{}
+
+	for _, entry := range entries {
+		topPath := filepath.Join(parent, entry.Name()) // !!! warning need path calc
+
+		result, err := s.mediator.Spawn(ctx, &core.ActiveState{
+			Tree: topPath,
+			// other members tbd
+		})
+
+		// We can do away with the concept of merging results
+
+		_, _ = compoundResult.Merge(result)
+
+		if err != nil {
+			return compoundResult, err
+		}
+	}
+
+	// TODO: check wether its ok to do this weird thing with the embedded error...
+	//
+	return compoundResult, compoundResult.Error() //nolint:gocritic // fuck off
+}
+
+func (s *spawnStrategy) following(parent, anchor string,
+	filesFirst, inclusive bool,
+) *shard {
+	// nil here is the fS(fs.ReadDirFS)
+	_, _ = s.o.Hooks.ReadDirectory.Invoke()(nil, parent)
+
+	// would it be better to just call a method on the mediator to
+	// read directory contents? That way, we can be abstracted away
+	// from the details of reading a directory, like having to
+	// need access to the fS ...
+	//
+	// s.mediator.Read(path)
+	//
+
+	_ = shard{
+		siblings: nil, // TODO: create new contents
+	}
+
+	panic(
+		fmt.Sprintf("NOT-IMPL: spawnStrategy.following, %v, %v, %v, %v",
+			parent, anchor, filesFirst, inclusive),
+	)
 }

--- a/internal/kernel/mediator.go
+++ b/internal/kernel/mediator.go
@@ -132,6 +132,14 @@ func (m *mediator) Resume(ctx context.Context,
 	})
 }
 
+// Connect combines information gleaned from the previous traversal that was
+// interrupted, into the resume traversal
+//
+// tree, current string
+func (m *mediator) Connect(_, _ string) {
+	// tbd...
+}
+
 func (m *mediator) Spawn(ctx context.Context,
 	active *core.ActiveState,
 ) (*types.KernelResult, error) {

--- a/internal/types/definitions.go
+++ b/internal/types/definitions.go
@@ -63,6 +63,7 @@ type (
 		Navigate(ctx context.Context) (*KernelResult, error)
 		Resume(ctx context.Context, active *core.ActiveState) (*KernelResult, error)
 		Spawn(ctx context.Context, active *core.ActiveState) (*KernelResult, error)
+		Connect(tree, current string)
 		Supervisor() *measure.Supervisor
 	}
 
@@ -139,49 +140,6 @@ type (
 		Loaded() *opts.LoadInfo
 	}
 )
-
-// KernelResult is the internal representation of core.TraverseResult
-type KernelResult struct {
-	session  core.Session
-	reporter core.Reporter
-	complete bool
-	err      error
-}
-
-func NewResult(session core.Session,
-	supervisor *measure.Supervisor,
-	err error,
-	complete bool,
-) *KernelResult {
-	return &KernelResult{
-		session:  session,
-		reporter: supervisor,
-		err:      err,
-		complete: complete,
-	}
-}
-
-func NewFailed(err error) *KernelResult {
-	return &KernelResult{
-		err: err,
-	}
-}
-
-func (r *KernelResult) IsComplete() bool {
-	return r.complete
-}
-
-func (r *KernelResult) Session() core.Session {
-	return r.session
-}
-
-func (r *KernelResult) Metrics() core.Reporter {
-	return r.reporter
-}
-
-func (r *KernelResult) Error() error {
-	return r.err
-}
 
 type (
 	FilterChildren interface { // TODO: is this still needed?

--- a/internal/types/enclave-suite_test.go
+++ b/internal/types/enclave-suite_test.go
@@ -1,0 +1,76 @@
+package types_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
+	. "github.com/onsi/gomega"    //nolint:revive // ok
+	"github.com/snivilised/traverse/enums"
+	lab "github.com/snivilised/traverse/internal/laboratory"
+	"github.com/snivilised/traverse/internal/measure"
+	"github.com/snivilised/traverse/internal/types"
+)
+
+func TestEnclave(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Enclave Suite")
+}
+
+type resultTE struct {
+	lab.NaviTE
+	arrange func(trig *trigger)
+	assert  func(a *asserter)
+}
+
+type session struct {
+	started time.Time
+}
+
+func (s *session) start() {
+	s.started = time.Now()
+}
+
+func (s *session) finish(_ *types.KernelResult) {
+
+}
+
+func (s *session) IsComplete() bool {
+	return false
+}
+
+func (s *session) StartedAt() time.Time {
+	return s.started
+}
+
+func (s *session) Elapsed() time.Duration {
+	return time.Since(s.started)
+}
+
+func (s *session) exec(_ context.Context) (*types.KernelResult, error) {
+	return &types.KernelResult{}, nil
+}
+
+type trigger struct {
+	mums measure.MutableMetrics
+}
+
+func (t *trigger) times(m enums.Metric, n uint) *trigger {
+	t.mums[m].Times(n)
+
+	return t
+}
+
+type asserter struct {
+	result *types.KernelResult
+}
+
+func (a *asserter) equals(m enums.Metric, n uint) *asserter {
+	Expect(a.result.Metrics().Count(
+		m,
+	)).To(BeEquivalentTo(n), fmt.Sprintf("💥 metric: '%v'", m))
+
+	return a
+}

--- a/internal/types/kernel-result.go
+++ b/internal/types/kernel-result.go
@@ -1,0 +1,55 @@
+package types
+
+import (
+	"errors"
+
+	"github.com/snivilised/traverse/core"
+	"github.com/snivilised/traverse/internal/measure"
+)
+
+// KernelResult is the internal representation of core.TraverseResult
+type KernelResult struct {
+	session  core.Session
+	reporter core.Reporter
+	complete bool
+	err      error
+}
+
+func NewResult(session core.Session,
+	supervisor *measure.Supervisor,
+	err error,
+	complete bool,
+) *KernelResult {
+	return &KernelResult{
+		session:  session,
+		reporter: supervisor,
+		err:      err,
+		complete: complete,
+	}
+}
+
+func NewFailed(err error) *KernelResult {
+	return &KernelResult{
+		err: err,
+	}
+}
+
+func (r *KernelResult) IsComplete() bool {
+	return r.complete
+}
+
+func (r *KernelResult) Session() core.Session {
+	return r.session
+}
+
+func (r *KernelResult) Metrics() core.Reporter {
+	return r.reporter
+}
+
+func (r *KernelResult) Error() error {
+	return r.err
+}
+
+func (r *KernelResult) Merge(other *KernelResult) (*KernelResult, error) {
+	return other, errors.New("NOT-IMPL: KernelResult.Merge")
+}

--- a/internal/types/kernel-result_test.go
+++ b/internal/types/kernel-result_test.go
@@ -1,0 +1,77 @@
+package types_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
+	"github.com/snivilised/traverse/enums"
+	lab "github.com/snivilised/traverse/internal/laboratory"
+	"github.com/snivilised/traverse/internal/measure"
+	"github.com/snivilised/traverse/internal/types"
+)
+
+var _ = Describe("KernelResult", func() {
+	Context("Metrics", Ordered, func() {
+		var (
+			sess     *session
+			reporter *measure.Supervisor
+			trig     *trigger
+			err      error
+			complete bool
+		)
+
+		BeforeEach(func() {
+			sess = &session{}
+			reporter = measure.New()
+			trig = &trigger{
+				mums: reporter.Many(
+					enums.MetricNoFilesInvoked,
+					enums.MetricNoFilesFilteredOut,
+					enums.MetricNoDirectoriesInvoked,
+					enums.MetricNoDirectoriesFilteredOut,
+				),
+			}
+			complete = false
+		})
+
+		DescribeTable("Times",
+			func(entry *resultTE) {
+				entry.arrange(trig)
+				result := types.NewResult(sess,
+					reporter,
+					err,
+					complete,
+				)
+				entry.assert(&asserter{
+					result: result,
+				})
+			},
+			func(entry *resultTE) string {
+				return fmt.Sprintf("🧪 ===> given: '%v', should: '%v'", entry.Given, entry.Should)
+			},
+
+			Entry(nil, &resultTE{
+				NaviTE: lab.NaviTE{
+					Given:  "metrics populated",
+					Should: "count metrics",
+				},
+				arrange: func(trig *trigger) {
+					trig.times(
+						enums.MetricNoFilesInvoked, 10).times(
+						enums.MetricNoFilesFilteredOut, 20).times(
+						enums.MetricNoDirectoriesInvoked, 30).times(
+						enums.MetricNoDirectoriesFilteredOut, 40,
+					)
+				},
+				assert: func(a *asserter) {
+					a.equals(
+						enums.MetricNoFilesInvoked, 10).equals(
+						enums.MetricNoFilesFilteredOut, 20).equals(
+						enums.MetricNoDirectoriesInvoked, 30).equals(
+						enums.MetricNoDirectoriesFilteredOut, 40,
+					)
+				},
+			}),
+		)
+	})
+})

--- a/traverse-api.go
+++ b/traverse-api.go
@@ -278,7 +278,7 @@ var (
 // ---
 //
 // 🔆 feature layer
-// resume: ["pref", "opts"]
+// resume: ["pref", "opts", "kernel"]
 // sampling: ["filter"]
 // hiber: ["filter", "services"]
 // filter: []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new task `ten` for testing internal types.
  - Added a new method `Connect` to the mediator for resuming interrupted traversals.
  - Enhanced the `Mediator` interface with a new `Connect` method.

- **Bug Fixes**
  - Corrected indentation in the `Taskfile.yml`.

- **Documentation**
  - Updated comments in `traverse-api.go` to reflect new dependencies for the "resume" feature.

- **Tests**
  - Added a comprehensive test suite for the "Enclave" functionality.
  - Introduced tests for the `KernelResult` type to validate expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->