### PR TITLE
fix(tv): enforce same fs type for resume (#301)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -88,6 +88,7 @@
     "Nuxx",
     "onsi",
     "outdir",
+    "pers",
     "Persistable",
     "Persistables",
     "pixa",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -120,7 +120,7 @@ tasks:
     cmds:
       - go test ./pref
 
-  tpers:
+  t-pers:
     cmds:
       - go test ./internal/persist
 

--- a/core/core-defs.go
+++ b/core/core-defs.go
@@ -59,14 +59,20 @@ type (
 	// during traversal.
 	Client func(servant Servant) error
 
+	FsDescription struct {
+		IsRelative bool
+	}
+
 	ActiveState struct {
-		Tree         string
-		Subscription enums.Subscription
-		Hibernation  enums.Hibernation
-		CurrentPath  string
-		IsDir        bool
-		Depth        int
-		Metrics      Metrics
+		Tree                string
+		TraverseDescription FsDescription
+		ResumeDescription   FsDescription
+		Subscription        enums.Subscription
+		Hibernation         enums.Hibernation
+		CurrentPath         string
+		IsDir               bool
+		Depth               int
+		Metrics             Metrics
 	}
 
 	// SimpleHandler is a function that takes no parameters and can

--- a/core/errors.go
+++ b/core/errors.go
@@ -216,3 +216,9 @@ var ErrWrongPrimaryFacade = errors.New(
 var ErrWrongResumeFacade = errors.New(
 	"wrong resume facade",
 )
+
+// ❌ Nil Forest error
+
+var ErrNilForest = errors.New(
+	"forest is nil",
+)

--- a/director-resume_test.go
+++ b/director-resume_test.go
@@ -9,16 +9,17 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
 	"github.com/snivilised/traverse/enums"
+	"github.com/snivilised/traverse/internal/enclave"
 	lab "github.com/snivilised/traverse/internal/laboratory"
 	"github.com/snivilised/traverse/internal/services"
 	"github.com/snivilised/traverse/life"
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("Director(Resume)", Ordered, func() {
@@ -61,14 +62,17 @@ var _ = Describe("Director(Resume)", Ordered, func() {
 
 				const depth = 2
 
-				_, err := tv.Walk().Configure().Extent(tv.Resume(
+				_, err := tv.Walk().Configure(enclave.Loader(func(active *core.ActiveState) {
+					active.TraverseDescription.IsRelative = true
+					active.ResumeDescription.IsRelative = false
+				})).Extent(tv.Resume(
 					&pref.Relic{
 						Head: pref.Head{
 							Handler: noOpHandler,
 							GetForest: func(_ string) *core.Forest {
 								return &core.Forest{
 									T: fS,
-									R: nef.NewTraverseABS(),
+									R: tfs.New(),
 								}
 							},
 						},

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/snivilised/li18ngo v0.1.9
-	github.com/snivilised/nefilim v0.1.8
+	github.com/snivilised/nefilim v0.1.9
 	github.com/snivilised/pants v0.1.2
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/snivilised/li18ngo v0.1.9 h1:xq+9yUv9JBY3fwzCzqCt0bIUdFlzDXcSjC2fQiSF
 github.com/snivilised/li18ngo v0.1.9/go.mod h1:7soFZVy6K6P8jgHYn0fN2Sw0r66isPa/K/K+r3fl19Q=
 github.com/snivilised/nefilim v0.1.8 h1:Srnl6rw7cB/cy3jQT8QfQ0ZNxumQX0Yj/Z+qH3+5TWc=
 github.com/snivilised/nefilim v0.1.8/go.mod h1:xcQnPeB+zVD+xgw9yzy0QiMTGqjYNEWKeoaZL0TBQeA=
+github.com/snivilised/nefilim v0.1.9 h1:KUUc4b8xeShDiiB15MuI4F9P1VlZF0bOwh/1UWsZLOA=
+github.com/snivilised/nefilim v0.1.9/go.mod h1:xcQnPeB+zVD+xgw9yzy0QiMTGqjYNEWKeoaZL0TBQeA=
 github.com/snivilised/pants v0.1.2 h1:6Abj02gV5rFYyKfCsmeEiOi1pLdRyITKUY5oDoRgYuU=
 github.com/snivilised/pants v0.1.2/go.mod h1:BOZa24yLxVjjnTCFWQeCzUWL8eK4TLtXtkz3pMdEFQM=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/internal/enclave/enclave-defs.go
+++ b/internal/enclave/enclave-defs.go
@@ -137,7 +137,8 @@ type (
 	}
 
 	// Loader is to be defined by a unit test and should modify the loaded active state
-	// for the test's own purposes.
+	// for the test's own purposes. This allows the unit tests to be isolated from the
+	// content of the loaded active state.
 	Loader func(active *core.ActiveState)
 
 	// OptionHarvest

--- a/internal/feat/hiber/hibernate_test.go
+++ b/internal/feat/hiber/hibernate_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 
 	tv "github.com/snivilised/traverse"
@@ -19,6 +18,7 @@ import (
 	"github.com/snivilised/traverse/internal/third/lo"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("feature", Ordered, func() {
@@ -66,7 +66,7 @@ var _ = Describe("feature", Ordered, func() {
 								GetForest: func(_ string) *core.Forest {
 									return &core.Forest{
 										T: fS,
-										R: nef.NewTraverseABS(),
+										R: tfs.New(),
 									}
 								},
 							},
@@ -148,7 +148,7 @@ var _ = Describe("feature", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/feat/hiber/with-filter_test.go
+++ b/internal/feat/hiber/with-filter_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/snivilised/traverse/internal/services"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("feature", Ordered, func() {
@@ -48,7 +48,7 @@ var _ = Describe("feature", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/feat/resume/resume-error_test.go
+++ b/internal/feat/resume/resume-error_test.go
@@ -1,22 +1,26 @@
 package resume_test
 
 import (
+	"context"
+	"fmt"
 	"io/fs"
 
+	"github.com/fortytw2/leaktest"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
 	"github.com/snivilised/traverse/enums"
+	"github.com/snivilised/traverse/internal/enclave"
 	lab "github.com/snivilised/traverse/internal/laboratory"
 	"github.com/snivilised/traverse/internal/services"
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("Resume Error", Ordered, func() {
@@ -33,17 +37,21 @@ var _ = Describe("Resume Error", Ordered, func() {
 				}
 			},
 		)).To(Succeed())
-
-		fS = hydra.Nuxx(verbose, lab.Static.RetroWave)
-		from = lab.GetJSONPath()
 	})
 
 	BeforeEach(func() {
 		services.Reset()
+		fS = hydra.Nuxx(verbose, lab.Static.RetroWave)
+		from = lab.GetJSONPath()
 	})
 
 	Context("given: resume path does not exist", func() {
-		It("🧪 should: return error", func(ctx SpecContext) {
+		It("🧪 should: return error", func(specCtx SpecContext) {
+			defer leaktest.Check(GinkgoT())()
+
+			ctx, cancel := context.WithCancel(specCtx)
+			defer cancel()
+
 			from = "/invalid-path"
 			_, err := tv.Walk().Configure().Extent(tv.Resume(
 				&pref.Relic{
@@ -54,7 +62,7 @@ var _ = Describe("Resume Error", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},
@@ -66,6 +74,85 @@ var _ = Describe("Resume Error", Ordered, func() {
 			)).Navigate(ctx)
 
 			Expect(err).To(MatchError(fs.ErrNotExist))
+		})
+	})
+
+	Context("forest creation failure", func() {
+		DescribeTable("fs type mismatch",
+			func(specCtx SpecContext, _ string, travIsRelative, resIsRelative bool) {
+				defer leaktest.Check(GinkgoT())()
+
+				ctx, cancel := context.WithCancel(specCtx)
+				defer cancel()
+
+				_, err := tv.Walk().Configure(enclave.Loader(func(active *core.ActiveState) {
+					active.Tree = lab.Static.RetroWave
+					active.CurrentPath = ResumeAtTeenageColor
+					active.Subscription = enums.SubscribeUniversal
+					active.TraverseDescription.IsRelative = travIsRelative
+					active.ResumeDescription.IsRelative = resIsRelative
+				})).Extent(tv.Resume(
+					&pref.Relic{
+						Head: pref.Head{
+							Handler: func(_ tv.Servant) error {
+								return nil
+							},
+							GetForest: func(_ string) *core.Forest {
+								return &core.Forest{
+									T: fS,
+									R: tfs.New(),
+								}
+							},
+						},
+						From:     from,
+						Strategy: enums.ResumeStrategyFastward,
+					},
+					tv.WithOnBegin(lab.Begin("🛡️")),
+					tv.WithOnEnd(lab.End("🏁")),
+				)).Navigate(ctx)
+
+				Expect(err).To(MatchError(locale.ErrCoreResumeFsMismatch))
+			},
+			func(given string, _, _ bool) string {
+				return fmt.Sprintf("🧪 ===> given: '%v'", given)
+			},
+			Entry(nil, "traverse-fs does not match", false, false),
+			Entry(nil, "resume-fs does not match", false, true),
+		)
+	})
+
+	When("custom forest creator returns nil", func() {
+		It("should: fail", func(specCtx SpecContext) {
+			defer leaktest.Check(GinkgoT())()
+
+			ctx, cancel := context.WithCancel(specCtx)
+			defer cancel()
+
+			_, err := tv.Walk().Configure(enclave.Loader(func(active *core.ActiveState) {
+				active.Tree = lab.Static.RetroWave
+				active.CurrentPath = ResumeAtTeenageColor
+				active.Subscription = enums.SubscribeUniversal
+				active.TraverseDescription.IsRelative = true
+				active.ResumeDescription.IsRelative = false
+			})).Extent(tv.Resume(
+				&pref.Relic{
+					Head: pref.Head{
+						Handler: func(_ tv.Servant) error {
+							return nil
+						},
+						GetForest: func(_ string) *core.Forest {
+							return nil
+						},
+					},
+					From:     from,
+					Strategy: enums.ResumeStrategyFastward,
+				},
+				tv.WithOnBegin(lab.Begin("🛡️")),
+				tv.WithOnEnd(lab.End("🏁")),
+			)).Navigate(ctx)
+
+			Expect(err).NotTo(Succeed())
+			Expect(err).To(MatchError(core.ErrNilForest))
 		})
 	})
 })

--- a/internal/feat/resume/resume_test.go
+++ b/internal/feat/resume/resume_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -19,6 +18,7 @@ import (
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 const (
@@ -101,6 +101,8 @@ var _ = Describe("Resume", Ordered, func() {
 						entry.active.resumeAt, entry.Subscription,
 					)
 					active.Tree = entry.Relative
+					active.TraverseDescription.IsRelative = true
+					active.ResumeDescription.IsRelative = false
 					active.Subscription = entry.Subscription
 					active.CurrentPath = entry.active.resumeAt
 					active.Hibernation = entry.active.listenState
@@ -111,7 +113,7 @@ var _ = Describe("Resume", Ordered, func() {
 							GetForest: func(_ string) *core.Forest {
 								return &core.Forest{
 									T: fS,
-									R: nef.NewTraverseABS(),
+									R: tfs.New(),
 								}
 							},
 						},

--- a/internal/feat/resume/strategy-spawn.go
+++ b/internal/feat/resume/strategy-spawn.go
@@ -113,6 +113,12 @@ func (s *spawnStrategy) seed(ctx context.Context,
 
 		intermediate, err := s.mediator.Spawn(ctx, &core.ActiveState{
 			Tree: top,
+			TraverseDescription: core.FsDescription{
+				IsRelative: s.forest.T.IsRelative(),
+			},
+			ResumeDescription: core.FsDescription{
+				IsRelative: s.forest.R.IsRelative(),
+			},
 			// Subscription: tbd,
 		})
 

--- a/internal/feat/sampling/navigator-sample_test.go
+++ b/internal/feat/sampling/navigator-sample_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -17,6 +16,7 @@ import (
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("feature", Ordered, func() {
@@ -55,7 +55,7 @@ var _ = Describe("feature", Ordered, func() {
 							GetForest: func(_ string) *core.Forest {
 								return &core.Forest{
 									T: fS,
-									R: nef.NewTraverseABS(),
+									R: tfs.New(),
 								}
 							},
 						},
@@ -118,7 +118,7 @@ var _ = Describe("feature", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/filtering/filter-custom_test.go
+++ b/internal/filtering/filter-custom_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -16,6 +15,7 @@ import (
 	"github.com/snivilised/traverse/internal/third/lo"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("NavigatorFilterCustom", Ordered, func() {
@@ -74,7 +74,7 @@ var _ = Describe("NavigatorFilterCustom", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/filtering/filter-errata_test.go
+++ b/internal/filtering/filter-errata_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -16,6 +15,7 @@ import (
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("NavigatorFilterCustom", Ordered, func() {
@@ -53,7 +53,7 @@ var _ = Describe("NavigatorFilterCustom", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/filtering/filter-glob-ex-child_test.go
+++ b/internal/filtering/filter-glob-ex-child_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -16,6 +15,7 @@ import (
 	"github.com/snivilised/traverse/internal/third/lo"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("filtering", Ordered, func() {
@@ -63,7 +63,7 @@ var _ = Describe("filtering", Ordered, func() {
 								GetForest: func(_ string) *core.Forest {
 									return &core.Forest{
 										T: fS,
-										R: nef.NewTraverseABS(),
+										R: tfs.New(),
 									}
 								},
 							},
@@ -133,7 +133,7 @@ var _ = Describe("filtering", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/filtering/filter-glob-ex_test.go
+++ b/internal/filtering/filter-glob-ex_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -16,6 +15,7 @@ import (
 	"github.com/snivilised/traverse/internal/third/lo"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("filtering", Ordered, func() {
@@ -63,7 +63,7 @@ var _ = Describe("filtering", Ordered, func() {
 								GetForest: func(_ string) *core.Forest {
 									return &core.Forest{
 										T: fS,
-										R: nef.NewTraverseABS(),
+										R: tfs.New(),
 									}
 								},
 							},
@@ -133,7 +133,7 @@ var _ = Describe("filtering", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/filtering/filter-glob_test.go
+++ b/internal/filtering/filter-glob_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -17,6 +16,7 @@ import (
 	"github.com/snivilised/traverse/internal/third/lo"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("NavigatorFilterGlob", Ordered, func() {
@@ -64,7 +64,7 @@ var _ = Describe("NavigatorFilterGlob", Ordered, func() {
 								GetForest: func(_ string) *core.Forest {
 									return &core.Forest{
 										T: fS,
-										R: nef.NewTraverseABS(),
+										R: tfs.New(),
 									}
 								},
 							},
@@ -134,7 +134,7 @@ var _ = Describe("NavigatorFilterGlob", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/filtering/filter-hybrid_test.go
+++ b/internal/filtering/filter-hybrid_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -17,6 +16,7 @@ import (
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("feature", Ordered, func() {
@@ -85,7 +85,7 @@ var _ = Describe("feature", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/filtering/filter-poly_test.go
+++ b/internal/filtering/filter-poly_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -19,6 +18,7 @@ import (
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("feature", Ordered, func() {
@@ -77,7 +77,7 @@ var _ = Describe("feature", Ordered, func() {
 								GetForest: func(_ string) *core.Forest {
 									return &core.Forest{
 										T: fS,
-										R: nef.NewTraverseABS(),
+										R: tfs.New(),
 									}
 								},
 							},
@@ -146,7 +146,7 @@ var _ = Describe("feature", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/filtering/filter-regex_test.go
+++ b/internal/filtering/filter-regex_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // ok
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -17,6 +16,7 @@ import (
 	"github.com/snivilised/traverse/internal/third/lo"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("feature", Ordered, func() {
@@ -66,7 +66,7 @@ var _ = Describe("feature", Ordered, func() {
 								GetForest: func(_ string) *core.Forest {
 									return &core.Forest{
 										T: fS,
-										R: nef.NewTraverseABS(),
+										R: tfs.New(),
 									}
 								},
 							},
@@ -136,7 +136,7 @@ var _ = Describe("feature", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/kernel/navigator-directories-with-files_test.go
+++ b/internal/kernel/navigator-directories-with-files_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -17,6 +16,7 @@ import (
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("NavigatorDirectoriesWithFiles", Ordered, func() {
@@ -64,7 +64,7 @@ var _ = Describe("NavigatorDirectoriesWithFiles", Ordered, func() {
 							GetForest: func(_ string) *core.Forest {
 								return &core.Forest{
 									T: fS,
-									R: nef.NewTraverseABS(),
+									R: tfs.New(),
 								}
 							},
 						},

--- a/internal/kernel/navigator-vanilla_test.go
+++ b/internal/kernel/navigator-vanilla_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive // ok
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	"github.com/snivilised/nefilim/test/luna"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
@@ -19,6 +18,7 @@ import (
 	"github.com/snivilised/traverse/locale"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 var _ = Describe("NavigatorUniversal", Ordered, func() {
@@ -77,7 +77,7 @@ var _ = Describe("NavigatorUniversal", Ordered, func() {
 						GetForest: func(_ string) *core.Forest {
 							return &core.Forest{
 								T: fS,
-								R: nef.NewTraverseABS(),
+								R: tfs.New(),
 							}
 						},
 					},

--- a/internal/persist/data/test-restore.DEFAULT.json
+++ b/internal/persist/data/test-restore.DEFAULT.json
@@ -40,6 +40,12 @@
   },
   "Active": {
     "Tree": "json/marshal",
+    "TraverseDescription": {
+      "IsRelative": true
+    },
+    "ResumeDescription": {
+      "IsRelative": false
+    },
     "Hibernation": 1,
     "CurrentPath": "/top/a/b/c",
     "IsDir": true,

--- a/internal/persist/marshaler-local-fs_test.go
+++ b/internal/persist/marshaler-local-fs_test.go
@@ -81,7 +81,10 @@ var _ = Describe("Marshaler", Ordered, func() {
 					jo, err := persist.Marshal(&persist.MarshalRequest{
 						O: o,
 						Active: &core.ActiveState{
-							Tree:        destination,
+							Tree: destination,
+							TraverseDescription: core.FsDescription{
+								IsRelative: writerFS.IsRelative(),
+							},
 							Hibernation: enums.HibernationPending,
 							CurrentPath: "/top/a/b/c",
 							Depth:       3,

--- a/locale/messages-errors.go
+++ b/locale/messages-errors.go
@@ -595,3 +595,100 @@ func (td InvalidPathTemplData) Message() *i18n.Message {
 		Other:       "path: {{.Path}}",
 	}
 }
+
+// 🍒 ResumeTraverseFsMismatch (dynamic i18n error)
+type TraverseFsMismatchTemplData struct {
+	traverseTemplData
+}
+
+func (td TraverseFsMismatchTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "traverse-fs-mismatch.dynamic-error",
+		Description: "traverse fs mismatch dynamic error (prefix for core mismatch error)",
+		Other:       "traverse-fs",
+	}
+}
+
+type TraverseFsMismatchError struct {
+	li18ngo.LocalisableError
+	Wrapped error
+}
+
+func (e TraverseFsMismatchError) Error() string {
+	return fmt.Sprintf("%v, %v", li18ngo.Text(e.Data), e.Wrapped.Error())
+}
+
+func (e TraverseFsMismatchError) Unwrap() error {
+	return e.Wrapped
+}
+
+func NewTraverseFsMismatchError() error {
+	return &TraverseFsMismatchError{
+		LocalisableError: li18ngo.LocalisableError{
+			Data: TraverseFsMismatchTemplData{},
+		},
+		Wrapped: ErrCoreResumeFsMismatch,
+	}
+}
+
+// 🍒 ResumeFsMismatch (dynamic i18n error)
+type ResumeFsMismatchTemplData struct {
+	traverseTemplData
+}
+
+func (td ResumeFsMismatchTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "resume-fs-mismatch.dynamic-error",
+		Description: "resume fs mismatch dynamic error (prefix for core mismatch error)",
+		Other:       "resume-fs",
+	}
+}
+
+type ResumeFsMismatchError struct {
+	li18ngo.LocalisableError
+	Wrapped error
+}
+
+func (e ResumeFsMismatchError) Error() string {
+	return fmt.Sprintf("%v, %v", li18ngo.Text(e.Data), e.Wrapped.Error())
+}
+
+func (e ResumeFsMismatchError) Unwrap() error {
+	return e.Wrapped
+}
+
+func NewResumeFsMismatchError() error {
+	return &ResumeFsMismatchError{
+		LocalisableError: li18ngo.LocalisableError{
+			Data: ResumeFsMismatchTemplData{},
+		},
+		Wrapped: ErrCoreResumeFsMismatch,
+	}
+}
+
+// 🥥 CoreResumeFsMismatch (core i18n error)
+type CoreResumeFsMismatchErrorTemplData struct {
+	traverseTemplData
+}
+
+func IsCoreResumeFsMismatchError(err error) bool {
+	return errors.Is(err, ErrCoreResumeFsMismatch)
+}
+
+func (td CoreResumeFsMismatchErrorTemplData) Message() *i18n.Message {
+	return &i18n.Message{
+		ID:          "core-resume-fs-mismatch.core-error",
+		Description: "core resume file system mismatch error",
+		Other:       "resume file system mismatch",
+	}
+}
+
+type CoreResumeFsMismatchError struct {
+	li18ngo.LocalisableError
+}
+
+var ErrCoreResumeFsMismatch = CoreResumeFsMismatchError{
+	LocalisableError: li18ngo.LocalisableError{
+		Data: CoreResumeFsMismatchErrorTemplData{},
+	},
+}

--- a/test/cmd/venus/main.go
+++ b/test/cmd/venus/main.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/snivilised/li18ngo"
-	nef "github.com/snivilised/nefilim"
 	tv "github.com/snivilised/traverse"
 	"github.com/snivilised/traverse/core"
 	"github.com/snivilised/traverse/enums"
@@ -17,6 +16,7 @@ import (
 	"github.com/snivilised/traverse/internal/third/lo"
 	"github.com/snivilised/traverse/pref"
 	"github.com/snivilised/traverse/test/hydra"
+	"github.com/snivilised/traverse/tfs"
 )
 
 const (
@@ -129,7 +129,7 @@ func navigate(n *navigation) {
 				GetForest: func(_ string) *core.Forest {
 					return &core.Forest{
 						T: fS,
-						R: nef.NewTraverseABS(),
+						R: tfs.New(),
 					}
 				},
 			},

--- a/tfs/local-fs.go
+++ b/tfs/local-fs.go
@@ -11,5 +11,5 @@ func NewFS(rel nef.Rel) TraversalFS {
 
 // New creates an absolute local file system required for traversal.
 func New() TraversalFS {
-	return nef.NewTraverseABS()
+	return nef.NewUniversalABS()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new fields for `TraverseDescription` and `ResumeDescription` in JSON configuration, providing context for traversal and resumption behaviors.
	- Introduced new error types for file system mismatches, enhancing error handling capabilities.
	
- **Bug Fixes**
	- Improved error handling in various functions to check for `nil` values in forest structures, ensuring robustness.

- **Refactor**
	- Updated imports from `nef` to `tfs`, reflecting a shift in the underlying implementation for traversal functionality across multiple files.
	- Consolidated forest management logic into platform-specific methods for better clarity and maintenance.

- **Documentation**
	- Enhanced comments and method signatures for clarity, particularly around the new `Loader` type and forest management functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->