### PR TITLE
fix(resume): sync spawn metrics (#325)

### DIFF
--- a/core/metrics.go
+++ b/core/metrics.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"maps"
+
 	"github.com/snivilised/agenor/enums"
 )
 
@@ -53,4 +55,19 @@ func (m *NavigationMetric) Times(increment uint) MetricValue {
 	m.Counter += increment
 
 	return m.Counter
+}
+
+func (m Metrics) Merge(other Metrics) {
+	for mt := range maps.Keys(m) {
+		if om, foundOther := other[mt]; foundOther {
+			if metric, found := m[mt]; found {
+				metric.Times(om.Counter)
+			} else {
+				m[mt] = &NavigationMetric{
+					T:       mt,
+					Counter: om.Counter,
+				}
+			}
+		}
+	}
 }

--- a/internal/enclave/kernel-result.go
+++ b/internal/enclave/kernel-result.go
@@ -7,7 +7,7 @@ import (
 // KernelResult is the internal representation of core.TraverseResult
 type KernelResult struct {
 	session  core.Session
-	reporter core.Reporter
+	reporter *Supervisor
 	complete bool
 }
 
@@ -24,6 +24,10 @@ func NewResult(session core.Session,
 
 func NewFailed() *KernelResult {
 	return &KernelResult{}
+}
+
+func (r *KernelResult) Merge(other core.Metrics) {
+	r.reporter.metrics.Merge(other)
 }
 
 func (r *KernelResult) IsComplete() bool {

--- a/internal/enclave/supervisor.go
+++ b/internal/enclave/supervisor.go
@@ -1,8 +1,6 @@
 package enclave
 
 import (
-	"maps"
-
 	"github.com/snivilised/agenor/core"
 	"github.com/snivilised/agenor/enums"
 )
@@ -24,7 +22,7 @@ func NewSupervisor() *Supervisor {
 }
 
 func (s *Supervisor) Load(metrics core.Metrics) {
-	s.metrics = maps.Clone(metrics)
+	s.metrics.Merge(metrics)
 }
 
 func (s *Supervisor) Single(mt enums.Metric) *core.NavigationMetric {

--- a/internal/feat/resume/resume_test.go
+++ b/internal/feat/resume/resume_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Resume", Ordered, func() {
 
 			fmt.Printf("💀💀💀 restore strategies\n")
 			for _, strategy := range []enums.ResumeStrategy{
-				enums.ResumeStrategyFastward,
+				// enums.ResumeStrategyFastward,
 				enums.ResumeStrategySpawn,
 			} {
 				recall := make(lab.Recall)

--- a/internal/kernel/mediator.go
+++ b/internal/kernel/mediator.go
@@ -102,6 +102,8 @@ func (m *mediator) Spawn(ctx context.Context,
 func (m *mediator) Bridge(active *core.ActiveState) {
 	m.tree = active.Tree
 	m.periscope.Offset(active.Depth)
+	m.Supervisor().Load(active.Metrics)
+
 	fmt.Printf("---> mediator.Bridge - tree %q, current %q\n",
 		active.Tree, active.CurrentPath,
 	)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `Merge` method for merging metrics in both `Metrics` and `KernelResult` structures.
	- Updated the `Load` method in `Supervisor` to merge metrics instead of cloning them.
	- Enhanced the `Bridge` method in the mediator to load metrics from the active state.

- **Bug Fixes**
	- Improved error handling in the `Navigate` method to log relevant errors.

- **Tests**
	- Adjusted the test suite for the "Resume" functionality by removing the `ResumeStrategyFastward` strategy from test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->