### PR TITLE
fix(age): swap the client handler, include missing updates (#347)

### DIFF
--- a/core/async.go
+++ b/core/async.go
@@ -42,14 +42,6 @@ type (
 		On     pants.OnCancel
 	}
 
-	// OutputController
-	OutputController interface {
-		Conclude(ctx context.Context)
-		StartCancellationMonitor(ctx context.Context,
-			cancellation *Cancellation,
-		)
-	}
-
 	// OutputFunc
 	OutputFunc func(outs OutputStream)
 )

--- a/internal/kernel/guardian.go
+++ b/internal/kernel/guardian.go
@@ -64,7 +64,6 @@ type guardian struct {
 	container iterationContainer
 	master    enclave.GuardianSealer
 	anchor    *anchor
-	swapped   core.Client
 }
 
 type guardianInfo struct {
@@ -163,7 +162,7 @@ func (g *guardian) iterate(servant core.Servant, inspection enclave.Inspection) 
 }
 
 func (g *guardian) Swap(decorator core.Client) {
-	g.swapped = g.anchor.swap(decorator)
+	_ = g.anchor.swap(decorator)
 }
 
 // Benign is used when a master sealer has not been registered. It is


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed the `OutputController` interface, streamlining functionality.
	- Simplified the `guardian` struct by removing the `swapped` field, enhancing state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->